### PR TITLE
feat: Added scrollToPosition.

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
@@ -19,7 +19,9 @@ fun addViewsAtAnchorEdge(
         layoutManager: LoopingLayoutManager,
         state: RecyclerView.State
 ): Int {
-    return layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_LOWER_INDICES)
+    val dir = layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_LOWER_INDICES)
+    Log.v("DirectionDecider", "$dir")
+    return dir
 }
 
 fun addViewsAtOptAnchorEdge(
@@ -37,10 +39,14 @@ fun estimateShortestRoute(
 ): Int {
     // Special case the view being partially visible.
     if (layoutManager.topLeftIndex == adapterIndex) {
+        Log.v("DirectionalDeciders", "topLeft is equal")
         return LoopingLayoutManager.TOWARDS_TOP_LEFT
     } else if (layoutManager.bottomRightIndex == adapterIndex) {
+        Log.v("DirectionalDeciders", "bottomRight is equal")
         return LoopingLayoutManager.TOWARDS_BOTTOM_RIGHT
     }
+
+    Log.v("DirectionalDeciders", "neither is equal")
 
     val (topLeftInLoopDist, topLeftOverSeamDist) = calculateDistances(
             adapterIndex, layoutManager.topLeftIndex, state.itemCount)

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
@@ -29,8 +29,7 @@ fun addViewsAtAnchorEdge(
         layoutManager: LoopingLayoutManager,
         state: RecyclerView.State
 ): Int {
-    val dir = layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_LOWER_INDICES)
-    return dir
+    return layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_LOWER_INDICES)
 }
 
 /**

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
@@ -1,0 +1,88 @@
+package com.bekawestberg.loopinglayout.library
+
+import android.util.Log
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+fun defaultDecider(
+        adapterIndex: Int,
+        layoutManager: LoopingLayoutManager,
+        state: RecyclerView.State
+): Int {
+    return estimateShortestRoute(adapterIndex, layoutManager, state)
+}
+
+fun addViewsAtAnchorEdge(
+        adapterIndex: Int,
+        layoutManager: LoopingLayoutManager,
+        state: RecyclerView.State
+): Int {
+    return layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_LOWER_INDICES)
+}
+
+fun addViewsAtOptAnchorEdge(
+        adapterIndex: Int,
+        layoutManager: LoopingLayoutManager,
+        state: RecyclerView.State
+): Int {
+    return layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_HIGHER_INDICES)
+}
+
+fun estimateShortestRoute(
+        adapterIndex: Int,
+        layoutManager: LoopingLayoutManager,
+        state: RecyclerView.State
+): Int {
+    // Special case the view being partially visible.
+    if (layoutManager.topLeftIndex == adapterIndex) {
+        return LoopingLayoutManager.TOWARDS_TOP_LEFT
+    } else if (layoutManager.bottomRightIndex == adapterIndex) {
+        return LoopingLayoutManager.TOWARDS_BOTTOM_RIGHT
+    }
+
+    val (topLeftInLoopDist, topLeftOverSeamDist) = calculateDistances(
+            adapterIndex, layoutManager.topLeftIndex, state.itemCount)
+    val topLeftTargetSmaller = adapterIndex < layoutManager.topLeftIndex
+
+    val (bottomRightInLoopDist, bottomRightOverSeamDist) = calculateDistances(
+            adapterIndex, layoutManager.bottomRightIndex, state.itemCount)
+    val bottomRightTargetSmaller = adapterIndex < layoutManager.bottomRightIndex
+
+    Log.v("DirectionDeciders", "$topLeftInLoopDist $topLeftOverSeamDist $bottomRightInLoopDist $bottomRightOverSeamDist")
+
+    val minDist = arrayOf(topLeftInLoopDist, topLeftOverSeamDist,
+            bottomRightInLoopDist, bottomRightOverSeamDist).min()
+    val minDistIsInLoop = when(minDist) {
+        topLeftInLoopDist, bottomRightInLoopDist -> true
+        topLeftOverSeamDist, bottomRightOverSeamDist -> false
+        else -> throw IllegalStateException()  // Should never happen.
+    }
+    val minDistIsOverSeam = !minDistIsInLoop
+    val targetIsSmaller = when(minDist) {
+        topLeftInLoopDist, topLeftOverSeamDist -> topLeftTargetSmaller
+        bottomRightInLoopDist, bottomRightOverSeamDist -> bottomRightTargetSmaller
+        else -> throw IllegalStateException()  // Should never happen.
+    }
+    val targetIsLarger = !targetIsSmaller
+
+    Log.v("DirectionDeciders", "is in loop? $minDistIsInLoop target smaller? $targetIsSmaller")
+
+    val adapterDir = when {
+        targetIsSmaller && minDistIsInLoop -> LoopingLayoutManager.TOWARDS_LOWER_INDICES
+        targetIsSmaller && minDistIsOverSeam -> LoopingLayoutManager.TOWARDS_HIGHER_INDICES
+        targetIsLarger && minDistIsInLoop -> LoopingLayoutManager.TOWARDS_HIGHER_INDICES
+        targetIsLarger && minDistIsOverSeam -> LoopingLayoutManager.TOWARDS_LOWER_INDICES
+        else -> throw IllegalStateException()  // Should never happen.
+    }
+    return layoutManager.convertAdapterDirToMovementDir(adapterDir)
+}
+
+internal fun calculateDistances(adapterIndex: Int, anchorIndex: Int, count: Int): Pair<Int, Int> {
+    val inLoopDist = abs(adapterIndex - anchorIndex)
+    val smallerIndex = min(adapterIndex, anchorIndex)
+    val largerIndex = max(adapterIndex, anchorIndex)
+    val overSeamDist = (count - largerIndex) + smallerIndex
+    return Pair(inLoopDist, overSeamDist)
+}

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -485,8 +485,8 @@ class LoopingLayoutManager : LayoutManager {
             isHorizontal && isTowardsHigher && isRTL && isReversed -> TOWARDS_BOTTOM_RIGHT
             isHorizontal && isTowardsLower && isLTR && isNotReversed -> TOWARDS_TOP_LEFT
             isHorizontal && isTowardsLower && isLTR && isReversed -> TOWARDS_BOTTOM_RIGHT
-            isHorizontal && isTowardsLower && isRTL && isNotReversed -> TOWARDS_TOP_LEFT
-            isHorizontal && isTowardsLower && isRTL && isReversed -> TOWARDS_BOTTOM_RIGHT
+            isHorizontal && isTowardsLower && isRTL && isNotReversed -> TOWARDS_BOTTOM_RIGHT
+            isHorizontal && isTowardsLower && isRTL && isReversed -> TOWARDS_TOP_LEFT
             else -> throw IllegalStateException("Invalid adapter state.")
         }
     }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
@@ -1,0 +1,373 @@
+package com.bekawestberg.loopinglayout.test
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.PositionAssertions.*
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
+import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.Thread.sleep
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see [Testing documentation](http://d.android.com/tools/testing)
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ScrollToAtAnchorTest {
+
+    internal var TAG = "ExampleInstrumentedTest"
+    // The width of the item associated with adapter index 0.
+    private val targetSize = 100
+    // Only show half the item when testing partial visibility.
+    private val targetVisiblePortion = targetSize / 2
+    // Makes the non-target view a little bit wider than the recycler so that
+    // the target is totally hidden.
+    private val nonTargetExtraPortion = 50
+
+
+    @get:Rule
+    var activityRule = ActivityTestRule(ActivityGeneric::class.java)
+
+    @Test
+    fun defaultHorizontalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetSize + nonTargetExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlPartiallyVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlPartiallyVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlPartiallyVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlPartiallyVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = nonTargetExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = nonTargetExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -(targetSize + nonTargetExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
+
+        onView(withText("1"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    fun calculateNonTargetSizeWhenPartiallyVisible(orientation: Int): Int {
+        val activity = activityRule.activity
+        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        return if (orientation == RecyclerView.HORIZONTAL) {
+            recycler.width - targetVisiblePortion
+        } else {
+            recycler.height - targetVisiblePortion
+        }
+    }
+
+    fun calculateNonTargetSizeWhenNotVisible(orientation: Int): Int {
+        val activity = activityRule.activity
+        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        return if (orientation == RecyclerView.HORIZONTAL) {
+            recycler.width + nonTargetExtraPortion
+        } else {
+            recycler.height + nonTargetExtraPortion
+        }
+    }
+}

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
@@ -1,0 +1,374 @@
+package com.bekawestberg.loopinglayout.test
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.PositionAssertions.*
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
+import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.Thread.sleep
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see [Testing documentation](http://d.android.com/tools/testing)
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ScrollToAtOptAnchorTest {
+
+    internal var TAG = "ExampleInstrumentedTest"
+    // The width of the item associated with adapter index 0.
+    private val targetSize = 100
+    // Only show half the item when testing partial visibility.
+    private val targetVisiblePortion = targetSize / 2
+    // Makes the non-target view a little bit wider than the recycler so that
+    // the target is totally hidden.
+    private val nonTargetExtraPortion = 50
+
+
+    @get:Rule
+    var activityRule = ActivityTestRule(ActivityGeneric::class.java)
+
+    @Test
+    fun defaultHorizontalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = nonTargetExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+
+    @Test
+    fun defaultHorizontalRtlPartiallyVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlPartiallyVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlPartiallyVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlPartiallyVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleAtAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetSize))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleAtOptAnchor() {
+        setRtl()
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = targetSize))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalPartiallyVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalPartiallyVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleAtAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -(targetSize + nonTargetExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleAtOptAnchor() {
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
+
+        onView(withText("1"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    fun calculateNonTargetSizeWhenPartiallyVisible(orientation: Int): Int {
+        val activity = activityRule.activity
+        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        return if (orientation == RecyclerView.HORIZONTAL) {
+            recycler.width - targetVisiblePortion
+        } else {
+            recycler.height - targetVisiblePortion
+        }
+    }
+
+    fun calculateNonTargetSizeWhenNotVisible(orientation: Int): Int {
+        val activity = activityRule.activity
+        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        return if (orientation == RecyclerView.HORIZONTAL) {
+            recycler.width + nonTargetExtraPortion
+        } else {
+            recycler.height + nonTargetExtraPortion
+        }
+    }
+}

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
@@ -1,0 +1,553 @@
+package com.bekawestberg.loopinglayout.test
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.PositionAssertions.*
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
+import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.Thread.sleep
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see [Testing documentation](http://d.android.com/tools/testing)
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ScrollToEstimatedShortestTest {
+
+    internal var TAG = "ExampleInstrumentedTest"
+    // The width of the item associated with adapter index 0.
+    private val targetSize = 100
+    // Only show half the item when testing partial visibility.
+    private val targetVisiblePortion = targetSize / 2
+    // Makes the view that fills the screen a little bit wider than the recycler so that
+    // the target is totally hidden.
+    private val fillerViewExtraPortion = 100
+    private val halfFillerViewExtraPortion = fillerViewExtraPortion / 2
+    private val otherViewSize = 100
+
+
+    @get:Rule
+    var activityRule = ActivityTestRule(ActivityGeneric::class.java)
+
+    @Test
+    fun defaultHorizontalPartiallyVisibleAtAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalPartiallyVisibleAtOptAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = (targetSize + targetVisiblePortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = (targetSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = halfFillerViewExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleOptAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = (otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalNotVisibleOptAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(
+                        x = (targetSize + otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalPartiallyVisibleAtAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalPartiallyVisibleAtOptAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + targetVisiblePortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -halfFillerViewExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleOptAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalNotVisibleOptAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(
+                        x = -(targetSize + otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlPartiallyVisibleAtAnchor() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlPartiallyVisibleAtOptAnchor() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + targetVisiblePortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleAnchorWithin() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(targetSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleAnchorSeam() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -halfFillerViewExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleOptAnchorWithin() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = -(otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultHorizontalRtlNotVisibleOptAnchorSeam() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(
+                        x = -(targetSize + otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlPartiallyVisibleAtAnchor() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlPartiallyVisibleAtOptAnchor() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = (targetSize + targetVisiblePortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleAnchorWithin() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = (targetSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleAnchorSeam() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = halfFillerViewExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isLeftAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleOptAnchorWithin() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(x = (otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseHorizontalRtlNotVisibleOptAnchorSeam() {
+        setRtl()
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(
+                        x = (targetSize + otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isRightAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalPartiallyVisibleAtAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalPartiallyVisibleAtOptAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = (targetSize + targetVisiblePortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = (targetSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = halfFillerViewExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleOptAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = (otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun defaultVerticalNotVisibleOptAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(
+                        y = (targetSize + otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalPartiallyVisibleAtAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -targetVisiblePortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalPartiallyVisibleAtOptAnchor() {
+        val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -(targetSize + targetVisiblePortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -(targetSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -halfFillerViewExtraPortion))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isBottomAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleOptAnchorWithin() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(y = -(otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(2))
+
+        onView(withText("2"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    @Test
+    fun reverseVerticalNotVisibleOptAnchorSeam() {
+        val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
+        setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
+        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        onView(withId(R.id.recycler))
+                .perform(RecyclerViewActions.scrollBy(
+                        y = -(targetSize + otherViewSize + halfFillerViewExtraPortion)))
+                .perform(RecyclerViewActions.scrollToPositionViaManager(0))
+
+        onView(withText("0"))
+                .check(isTopAlignedWith(withId(R.id.recycler)))
+    }
+
+    fun calculateFillerSizeWhenPartiallyVisible(orientation: Int): Int {
+        val activity = activityRule.activity
+        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        return if (orientation == RecyclerView.HORIZONTAL) {
+            recycler.width
+        } else {
+            recycler.height
+        }
+    }
+
+    fun calculateFillerSizeWhenNotVisible(orientation: Int): Int {
+        val activity = activityRule.activity
+        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        return if (orientation == RecyclerView.HORIZONTAL) {
+            recycler.width + fillerViewExtraPortion
+        } else {
+            recycler.height + fillerViewExtraPortion
+        }
+    }
+}

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
@@ -38,7 +38,9 @@ class ScrollToEstimatedShortestTest {
     // Makes the view that fills the screen a little bit wider than the recycler so that
     // the target is totally hidden.
     private val fillerViewExtraPortion = 100
+    // Used to center the filler view so that there is equal extra on either side.
     private val halfFillerViewExtraPortion = fillerViewExtraPortion / 2
+    // A constant size to use for views that are not the filler view, and are not the target view.
     private val otherViewSize = 100
 
 

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/RecyclerViewActions.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/RecyclerViewActions.kt
@@ -29,6 +29,9 @@ import androidx.test.espresso.util.HumanReadables
 import org.hamcrest.Matcher
 
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
+import com.bekawestberg.loopinglayout.library.defaultDecider
 
 object RecyclerViewActions {
     fun setLayoutManager(manager: RecyclerView.LayoutManager): ViewAction {
@@ -118,6 +121,34 @@ object RecyclerViewActions {
                         .withCause(e)
                         .build()
             }
+        }
+    }
+
+    fun scrollToPositionViaManager(
+            position: Int,
+            strategy: (Int, LoopingLayoutManager, RecyclerView.State) -> Int = ::defaultDecider
+    ): ViewAction {
+        return ScrollToPositionViaManagerAction(position, strategy)
+    }
+
+    class ScrollToPositionViaManagerAction(
+            val position: Int,
+            val strategy: (Int, LoopingLayoutManager, RecyclerView.State) -> Int
+    ) : ViewAction {
+
+        override fun getConstraints(): Matcher<View> {
+            return isAssignableFrom(RecyclerView::class.java)
+        }
+
+        override fun getDescription(): String {
+            return "Could not scroll the recycler."
+        }
+
+        override fun perform(uiController: UiController, view: View) {
+            val recyclerView = view as RecyclerView
+            (recyclerView.layoutManager as LoopingLayoutManager)
+                    .scrollToPosition(position, strategy)
+            uiController.loopMainThreadUntilIdle()
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/RecyclerViewActions.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/RecyclerViewActions.kt
@@ -18,20 +18,15 @@
 package com.bekawestberg.loopinglayout.test.androidTest.utils
 
 import android.view.View
-import android.widget.Adapter
-
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.PerformException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
-import androidx.test.espresso.util.HumanReadables
-
-import org.hamcrest.Matcher
-
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.util.HumanReadables
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
-import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
 import com.bekawestberg.loopinglayout.library.defaultDecider
+import org.hamcrest.Matcher
 
 object RecyclerViewActions {
     fun setLayoutManager(manager: RecyclerView.LayoutManager): ViewAction {

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityGeneric.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityGeneric.kt
@@ -19,7 +19,6 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityGeneric.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityGeneric.kt
@@ -19,6 +19,7 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -19,18 +19,15 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
-import com.bekawestberg.loopinglayout.library.estimateShortestRoute
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityHorizontal : AppCompatActivity() {
     private lateinit var mRecyclerView: RecyclerView
     private var mAdapter: AdapterGeneric = AdapterGeneric(
             arrayOf("0", "1", "2"/*, "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"*/))
-
     private var mLayoutManager =
             LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
 

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -29,7 +29,8 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 class ActivityHorizontal : AppCompatActivity() {
     private lateinit var mRecyclerView: RecyclerView
     private var mAdapter: AdapterGeneric = AdapterGeneric(
-            arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"/**/))
+            arrayOf("0", "1", "2"/*, "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"*/))
+
     private var mLayoutManager =
             LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
 
@@ -45,6 +46,6 @@ class ActivityHorizontal : AppCompatActivity() {
         mRecyclerView.adapter = mAdapter
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
-        button.setOnClickListener { mLayoutManager.scrollToPosition(7, ::estimateShortestRoute) }
+        button.setOnClickListener { mLayoutManager.scrollToPosition(0, ::addViewsAtAnchorEdge) }
     }
 }

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -19,8 +19,11 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
+import com.bekawestberg.loopinglayout.library.estimateShortestRoute
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityHorizontal : AppCompatActivity() {
@@ -42,6 +45,6 @@ class ActivityHorizontal : AppCompatActivity() {
         mRecyclerView.adapter = mAdapter
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
-        button.setOnClickListener { mRecyclerView.scrollToPosition(15) }
+        button.setOnClickListener { mLayoutManager.scrollToPosition(7, ::estimateShortestRoute) }
     }
 }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #5
     
### :star2: Description

<!-- A description of what your PR does -->
Adds support for the scrollToPosition function.

This mostly follows the original proposal in the issue. There are only two main differences:
1. There is no strategy for picking which view to scroll to, because the default behavior is that if there is already a view visible, no scrolling occures.
2. Instead of an enum-esc value for determining the movement direction I decided to allow passing a function. This has to do with the following:

The default direction-determining strategy estimates which direction would be shortest. This assumes that all of the views in the recycler are the same size. If they are not the same size this function could be incorrect.

With a function-based system, if a developer has views with varying sizes, they can pass their own function that takes these differences into account.

By default I decided to provide three DirectionDecider functions:
* addViewsAtAnchorEdge  
  New views will be added at the anchor edge until the target view is visible.
* addViewsAtOptAnchorEdge  
  New views will be added at the edge opposite teh anchor edge until the target view is visible.
* estimateShortestRoute  
  As described above, this attempts to minimize the amount of scrolling.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Lots of tests! 84 in total.

* addViewsToAnchorEdge (24)
  * Partially visible and Fully hidden
  * At anchor edge and At opt anchor edge
  * Vertical and Horizontal
  * RTL and LTR
  * Reversed and Not Reversed
* addViewsToOptAnchorEdge (24)
  * Partially visible and Fully hidden
  * At anchor edge and At opt anchor edge
  * Vertical and Horizontal
  * RTL and LTR
  * Reversed and Not Reversed
* estimateClosestRoute (36)
  * Within loop and Over seam. (has to do with whether we cross 0)
  * Partially visible and Fully hidden
  * At anchor edge and At opt anchor edge
  * Vertical and Horizontal
  * RTL and LTR
  * Reversed and Not Reversed

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A