### PR TITLE
Feat/smooth scrolling

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/DirectionDeciders.kt
@@ -13,9 +13,9 @@ import kotlin.math.min
 fun defaultDecider(
         adapterIndex: Int,
         layoutManager: LoopingLayoutManager,
-        state: RecyclerView.State
+        itemCount: Int
 ): Int {
-    return estimateShortestRoute(adapterIndex, layoutManager, state)
+    return estimateShortestRoute(adapterIndex, layoutManager, itemCount)
 }
 
 /**
@@ -27,7 +27,7 @@ fun defaultDecider(
 fun addViewsAtAnchorEdge(
         adapterIndex: Int,
         layoutManager: LoopingLayoutManager,
-        state: RecyclerView.State
+        itemCount: Int
 ): Int {
     return layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_LOWER_INDICES)
 }
@@ -41,7 +41,7 @@ fun addViewsAtAnchorEdge(
 fun addViewsAtOptAnchorEdge(
         adapterIndex: Int,
         layoutManager: LoopingLayoutManager,
-        state: RecyclerView.State
+        itemCount: Int
 ): Int {
     return layoutManager.convertAdapterDirToMovementDir(LoopingLayoutManager.TOWARDS_HIGHER_INDICES)
 }
@@ -56,7 +56,7 @@ fun addViewsAtOptAnchorEdge(
 fun estimateShortestRoute(
         adapterIndex: Int,
         layoutManager: LoopingLayoutManager,
-        state: RecyclerView.State
+        itemCount: Int
 ): Int {
     // Special case the view being partially visible.
     if (layoutManager.topLeftIndex == adapterIndex) {
@@ -66,11 +66,11 @@ fun estimateShortestRoute(
     }
 
     val (topLeftInLoopDist, topLeftOverSeamDist) = calculateDistances(
-            adapterIndex, layoutManager.topLeftIndex, state.itemCount)
+            adapterIndex, layoutManager.topLeftIndex, itemCount)
     val topLeftTargetSmaller = adapterIndex < layoutManager.topLeftIndex
 
     val (bottomRightInLoopDist, bottomRightOverSeamDist) = calculateDistances(
-            adapterIndex, layoutManager.bottomRightIndex, state.itemCount)
+            adapterIndex, layoutManager.bottomRightIndex, itemCount)
     val bottomRightTargetSmaller = adapterIndex < layoutManager.bottomRightIndex
 
     val minDist = arrayOf(topLeftInLoopDist, topLeftOverSeamDist,

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -29,7 +29,7 @@ import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import androidx.recyclerview.widget.RecyclerView.LayoutParams
 import kotlin.math.abs
 
-class LoopingLayoutManager : LayoutManager {
+class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVectorProvider {
 
     /**
      * When LayoutManager needs to scroll to a position, it sets this variable and requests a
@@ -431,91 +431,6 @@ class LoopingLayoutManager : LayoutManager {
     }
 
     /**
-     * Returns the direction we are moving through the adapter (Either
-     * [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES]) based on the direction
-     * the list is being scrolled in, and the current layout settings.
-     * @param direction The direction the list is being scrolled in. Either [.TOWARDS_TOP_LEFT]
-     * or [.TOWARDS_BOTTOM_RIGHT]
-     * @return the direction we are moving through the adapter. Either
-     * [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES].
-     */
-    private fun getAdapterDirectionFromMovementDirection(direction: Int): Int {
-        val isVertical = orientation == VERTICAL
-        val isHorizontal = !isVertical
-        val isTowardsTopLeft = direction == TOWARDS_TOP_LEFT
-        val isTowardsBottomRight = !isTowardsTopLeft
-        val isRTL = isLayoutRTL
-        val isLTR = !isRTL
-        val isReversed = reverseLayout
-        val isNotReversed = !isReversed
-
-        return when {
-            isVertical && isTowardsTopLeft && isNotReversed -> TOWARDS_LOWER_INDICES
-            isVertical && isTowardsTopLeft && isReversed -> TOWARDS_HIGHER_INDICES
-            isVertical && isTowardsBottomRight && isNotReversed -> TOWARDS_HIGHER_INDICES
-            isVertical && isTowardsBottomRight && isReversed -> TOWARDS_LOWER_INDICES
-            isHorizontal && isTowardsTopLeft && isLTR && isNotReversed -> TOWARDS_LOWER_INDICES
-            isHorizontal && isTowardsTopLeft && isLTR && isReversed -> TOWARDS_HIGHER_INDICES
-            isHorizontal && isTowardsTopLeft && isRTL && isNotReversed -> TOWARDS_HIGHER_INDICES
-            isHorizontal && isTowardsTopLeft && isRTL && isReversed -> TOWARDS_LOWER_INDICES
-            isHorizontal && isTowardsBottomRight && isLTR && isNotReversed -> TOWARDS_HIGHER_INDICES
-            isHorizontal && isTowardsBottomRight && isLTR && isReversed -> TOWARDS_LOWER_INDICES
-            isHorizontal && isTowardsBottomRight && isRTL && isNotReversed -> TOWARDS_LOWER_INDICES
-            isHorizontal && isTowardsBottomRight && isRTL && isReversed -> TOWARDS_HIGHER_INDICES
-            else -> throw IllegalStateException("Invalid movement state.")
-        }
-    }
-
-    /**
-     * Converts an adapter direction ([.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES]) to
-     * a movement direction. A movement direction tells us which direction we should traverse
-     * the views in (first -> last or last -> first) so that we are traversing in the given
-     * adapter direction.
-     * @param direction The direction we want to traverse the adapter indices in.
-     * Either [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES].
-     * @return The direction we need to traverse the views in to get to adapter indices in the
-     * given direction.
-     */
-    fun convertAdapterDirToMovementDir(direction: Int): Int {
-        return getMovementDirectionFromAdapterDirection(direction)
-    }
-
-    /**
-     * Returns the direction we need to move the views in to get to adapter indices in the
-     * given direction.
-     * @param direction The direction we want to traverse the adapter indices in.
-     * Either [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES].
-     * @return The direction we need to move the views in to get to adapter indices in the
-     * given direction.
-     */
-    private fun getMovementDirectionFromAdapterDirection(direction: Int): Int {
-        val isVertical = orientation == VERTICAL
-        val isHorizontal = !isVertical
-        val isTowardsHigher = direction == TOWARDS_HIGHER_INDICES
-        val isTowardsLower = !isTowardsHigher
-        val isRTL = isLayoutRTL
-        val isLTR = !isRTL
-        val isReversed = reverseLayout
-        val isNotReversed = !isReversed
-
-        return when {
-            isVertical && isTowardsHigher && isNotReversed -> TOWARDS_BOTTOM_RIGHT
-            isVertical && isTowardsHigher && isReversed -> TOWARDS_TOP_LEFT
-            isVertical && isTowardsLower && isNotReversed -> TOWARDS_TOP_LEFT
-            isVertical && isTowardsLower && isReversed -> TOWARDS_BOTTOM_RIGHT
-            isHorizontal && isTowardsHigher && isLTR && isNotReversed -> TOWARDS_BOTTOM_RIGHT
-            isHorizontal && isTowardsHigher && isLTR && isReversed -> TOWARDS_TOP_LEFT
-            isHorizontal && isTowardsHigher && isRTL && isNotReversed -> TOWARDS_TOP_LEFT
-            isHorizontal && isTowardsHigher && isRTL && isReversed -> TOWARDS_BOTTOM_RIGHT
-            isHorizontal && isTowardsLower && isLTR && isNotReversed -> TOWARDS_TOP_LEFT
-            isHorizontal && isTowardsLower && isLTR && isReversed -> TOWARDS_BOTTOM_RIGHT
-            isHorizontal && isTowardsLower && isRTL && isNotReversed -> TOWARDS_BOTTOM_RIGHT
-            isHorizontal && isTowardsLower && isRTL && isReversed -> TOWARDS_TOP_LEFT
-            else -> throw IllegalStateException("Invalid adapter state.")
-        }
-    }
-
-    /**
      * Returns the view wrapped in the correct ListItem based on the movement direction and
      * configuration of the LayoutManager.
      *
@@ -619,6 +534,93 @@ class LoopingLayoutManager : LayoutManager {
             getDecoratedTop(view) >= paddingTop && getDecoratedBottom(view) <= height - paddingBottom
         }
     }
+
+    /**
+     * Returns the direction we are moving through the adapter (Either
+     * [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES]) based on the direction
+     * the list is being scrolled in, and the current layout settings.
+     * @param direction The direction the list is being scrolled in. Either [.TOWARDS_TOP_LEFT]
+     * or [.TOWARDS_BOTTOM_RIGHT]
+     * @return the direction we are moving through the adapter. Either
+     * [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES].
+     */
+    private fun getAdapterDirectionFromMovementDirection(direction: Int): Int {
+        val isVertical = orientation == VERTICAL
+        val isHorizontal = !isVertical
+        val isTowardsTopLeft = direction == TOWARDS_TOP_LEFT
+        val isTowardsBottomRight = !isTowardsTopLeft
+        val isRTL = isLayoutRTL
+        val isLTR = !isRTL
+        val isReversed = reverseLayout
+        val isNotReversed = !isReversed
+
+        return when {
+            isVertical && isTowardsTopLeft && isNotReversed -> TOWARDS_LOWER_INDICES
+            isVertical && isTowardsTopLeft && isReversed -> TOWARDS_HIGHER_INDICES
+            isVertical && isTowardsBottomRight && isNotReversed -> TOWARDS_HIGHER_INDICES
+            isVertical && isTowardsBottomRight && isReversed -> TOWARDS_LOWER_INDICES
+            isHorizontal && isTowardsTopLeft && isLTR && isNotReversed -> TOWARDS_LOWER_INDICES
+            isHorizontal && isTowardsTopLeft && isLTR && isReversed -> TOWARDS_HIGHER_INDICES
+            isHorizontal && isTowardsTopLeft && isRTL && isNotReversed -> TOWARDS_HIGHER_INDICES
+            isHorizontal && isTowardsTopLeft && isRTL && isReversed -> TOWARDS_LOWER_INDICES
+            isHorizontal && isTowardsBottomRight && isLTR && isNotReversed -> TOWARDS_HIGHER_INDICES
+            isHorizontal && isTowardsBottomRight && isLTR && isReversed -> TOWARDS_LOWER_INDICES
+            isHorizontal && isTowardsBottomRight && isRTL && isNotReversed -> TOWARDS_LOWER_INDICES
+            isHorizontal && isTowardsBottomRight && isRTL && isReversed -> TOWARDS_HIGHER_INDICES
+            else -> throw IllegalStateException("Invalid movement state.")
+        }
+    }
+
+    /**
+     * Converts an adapter direction ([.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES]) to
+     * a movement direction. A movement direction tells us which direction we should traverse
+     * the views in (first -> last or last -> first) so that we are traversing in the given
+     * adapter direction.
+     * @param direction The direction we want to traverse the adapter indices in.
+     * Either [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES].
+     * @return The direction we need to traverse the views in to get to adapter indices in the
+     * given direction.
+     */
+    fun convertAdapterDirToMovementDir(direction: Int): Int {
+        return getMovementDirectionFromAdapterDirection(direction)
+    }
+
+    /**
+     * Returns the direction we need to move the views in to get to adapter indices in the
+     * given direction.
+     * @param direction The direction we want to traverse the adapter indices in.
+     * Either [.TOWARDS_HIGHER_INDICES] or [.TOWARDS_LOWER_INDICES].
+     * @return The direction we need to move the views in to get to adapter indices in the
+     * given direction.
+     */
+    private fun getMovementDirectionFromAdapterDirection(direction: Int): Int {
+        val isVertical = orientation == VERTICAL
+        val isHorizontal = !isVertical
+        val isTowardsHigher = direction == TOWARDS_HIGHER_INDICES
+        val isTowardsLower = !isTowardsHigher
+        val isRTL = isLayoutRTL
+        val isLTR = !isRTL
+        val isReversed = reverseLayout
+        val isNotReversed = !isReversed
+
+        return when {
+            isVertical && isTowardsHigher && isNotReversed -> TOWARDS_BOTTOM_RIGHT
+            isVertical && isTowardsHigher && isReversed -> TOWARDS_TOP_LEFT
+            isVertical && isTowardsLower && isNotReversed -> TOWARDS_TOP_LEFT
+            isVertical && isTowardsLower && isReversed -> TOWARDS_BOTTOM_RIGHT
+            isHorizontal && isTowardsHigher && isLTR && isNotReversed -> TOWARDS_BOTTOM_RIGHT
+            isHorizontal && isTowardsHigher && isLTR && isReversed -> TOWARDS_TOP_LEFT
+            isHorizontal && isTowardsHigher && isRTL && isNotReversed -> TOWARDS_TOP_LEFT
+            isHorizontal && isTowardsHigher && isRTL && isReversed -> TOWARDS_BOTTOM_RIGHT
+            isHorizontal && isTowardsLower && isLTR && isNotReversed -> TOWARDS_TOP_LEFT
+            isHorizontal && isTowardsLower && isLTR && isReversed -> TOWARDS_BOTTOM_RIGHT
+            isHorizontal && isTowardsLower && isRTL && isNotReversed -> TOWARDS_BOTTOM_RIGHT
+            isHorizontal && isTowardsLower && isRTL && isReversed -> TOWARDS_TOP_LEFT
+            else -> throw IllegalStateException("Invalid adapter state.")
+        }
+    }
+
+
 
     /**
      * Finds the view with the given adapter position.

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/RecyclerViewActions.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/RecyclerViewActions.kt
@@ -121,14 +121,14 @@ object RecyclerViewActions {
 
     fun scrollToPositionViaManager(
             position: Int,
-            strategy: (Int, LoopingLayoutManager, RecyclerView.State) -> Int = ::defaultDecider
+            strategy: (Int, LoopingLayoutManager, Int) -> Int = ::defaultDecider
     ): ViewAction {
         return ScrollToPositionViaManagerAction(position, strategy)
     }
 
     class ScrollToPositionViaManagerAction(
             val position: Int,
-            val strategy: (Int, LoopingLayoutManager, RecyclerView.State) -> Int
+            val strategy: (Int, LoopingLayoutManager, Int) -> Int
     ) : ViewAction {
 
         override fun getConstraints(): Matcher<View> {

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -21,13 +21,14 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
-import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
+import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityHorizontal : AppCompatActivity() {
     private lateinit var mRecyclerView: RecyclerView
     private var mAdapter: AdapterGeneric = AdapterGeneric(
-            arrayOf("0", "1", "2"/*, "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"*/))
+            arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"),
+            Array(16) { i -> 250})
     private var mLayoutManager =
             LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
 
@@ -41,8 +42,9 @@ class ActivityHorizontal : AppCompatActivity() {
         mRecyclerView.setHasFixedSize(true)
         mRecyclerView.layoutManager = mLayoutManager
         mRecyclerView.adapter = mAdapter
+        mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
-        button.setOnClickListener { mLayoutManager.scrollToPosition(0, ::addViewsAtAnchorEdge) }
+        button.setOnClickListener { mRecyclerView.smoothScrollToPosition(7) }
     }
 }

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
@@ -22,11 +22,13 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityVertical : AppCompatActivity() {
     private lateinit var mRecyclerView: RecyclerView
     private var mAdapter: AdapterGeneric = AdapterGeneric(
-            arrayOf("0", "1", "2", "3", "4", "5", "6"/**/))
+            arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"))
     private var mLayoutManager: LoopingLayoutManager =
             LoopingLayoutManager(this, LoopingLayoutManager.VERTICAL, false)
 
@@ -40,5 +42,9 @@ class ActivityVertical : AppCompatActivity() {
         mRecyclerView.setHasFixedSize(true)
         mRecyclerView.layoutManager = mLayoutManager
         mRecyclerView.adapter = mAdapter
+        mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge
+
+        val button = findViewById<FloatingActionButton>(R.id.fab)
+        button.setOnClickListener { mRecyclerView.smoothScrollToPosition(7) }
     }
 }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #6 
     
### :star2: Description

<!-- A description of what your PR does -->

* Changes DirectionDeciders to take in an item count rather than a state. This allows them to be called in a situation where we don't have a state, but can access the adapter item count.
* Adds a custom SmoothScroller that works with the LoopingLayoutManager's particular quirks.
* LoopingLayoutManager now implements ScrollVectorProvide. Not necessary because of the custom SmoothScroller, but it is good for consistency. (ScrollVectorProvider is honestly kind of a weird OOP decision. What LayoutManager is there that wants to use the LinearSmoothScroller, but doesn't want to inherit from LinearLayoutManager?)
* LoopingLayoutManager now has the ability to lay out extra non-visible views (i.e. views that are beyond the bounds of the recycler). This is necessary because the smooth scroller needs to find the view before it is visible, so that it can begin decelerating.
* Adds a `smoothScrollDirectionDecider` property which can be set my developer. This is used to determine the direction when smooth scrolling. Set to default (currently estimateShortestRoute) by default.

* Moves direction-conversion functions lower in the file. Non-functional change.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
I was unable to find an effective way to test this programmatically, because espresso doesn't seem to support [testing animations](https://developer.android.com/training/testing/espresso/setup#set-up-environment).

I did test manually (although not in all orietnations) and it seems to be working well.

All of the current unit tests passed.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A