### PR TITLE
feat: Added state saving.

### DIFF
--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
@@ -45,310 +45,336 @@ class ScrollToAtAnchorTest {
 
     @Test
     fun defaultHorizontalPartiallyVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultHorizontalPartiallyVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalNotVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetSize + nonTargetExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultHorizontalNotVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalPartiallyVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalPartiallyVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalNotVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalNotVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultHorizontalRtlPartiallyVisibleAtAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalRtlPartiallyVisibleAtOptAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultHorizontalRtlNotVisibleAtAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalRtlNotVisibleAtOptAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalRtlPartiallyVisibleAtAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalRtlPartiallyVisibleAtOptAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalRtlNotVisibleAtAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = nonTargetExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalRtlNotVisibleAtOptAnchor() {
         setRtl()
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultVerticalPartiallyVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultVerticalPartiallyVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultVerticalNotVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = nonTargetExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultVerticalNotVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalPartiallyVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalPartiallyVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseVerticalNotVisibleAtAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -(targetSize + nonTargetExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalNotVisibleAtOptAnchor() {
-        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
+        val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     fun calculateNonTargetSizeWhenPartiallyVisible(orientation: Int): Int {

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
@@ -1,10 +1,8 @@
 package com.bekawestberg.loopinglayout.test
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.PositionAssertions.*
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,7 +17,6 @@ import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Thread.sleep
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
@@ -1,10 +1,8 @@
 package com.bekawestberg.loopinglayout.test
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.PositionAssertions.*
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,7 +17,6 @@ import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Thread.sleep
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -47,100 +44,108 @@ class ScrollToAtOptAnchorTest {
     fun defaultHorizontalPartiallyVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalPartiallyVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalNotVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = nonTargetExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalNotVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalPartiallyVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalPartiallyVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalNotVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalNotVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
 
@@ -149,13 +154,14 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
@@ -163,12 +169,13 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -176,13 +183,14 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + nonTargetExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
@@ -190,12 +198,13 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -203,13 +212,14 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -217,12 +227,13 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
@@ -230,13 +241,14 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetSize))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -244,112 +256,121 @@ class ScrollToAtOptAnchorTest {
         setRtl()
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.HORIZONTAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultVerticalPartiallyVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultVerticalPartiallyVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultVerticalNotVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = targetSize))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultVerticalNotVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseVerticalPartiallyVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseVerticalPartiallyVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenPartiallyVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalNotVisibleAtAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -(targetSize + nonTargetExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseVerticalNotVisibleAtOptAnchor() {
         val nonTargetSize = calculateNonTargetSizeWhenNotVisible(RecyclerView.VERTICAL);
         setAdapter(arrayOf("0", "1"), arrayOf(nonTargetSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     fun calculateNonTargetSizeWhenPartiallyVisible(orientation: Int): Int {

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
@@ -51,72 +51,77 @@ class ScrollToEstimatedShortestTest {
     fun defaultHorizontalPartiallyVisibleAtAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultHorizontalPartiallyVisibleAtOptAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = (targetSize + targetVisiblePortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalNotVisibleAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = (targetSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
     fun defaultHorizontalNotVisibleAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = halfFillerViewExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultHorizontalNotVisibleOptAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = (otherViewSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
     fun defaultHorizontalNotVisibleOptAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(
                         x = (targetSize + otherViewSize + halfFillerViewExtraPortion)))
@@ -124,78 +129,84 @@ class ScrollToEstimatedShortestTest {
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalPartiallyVisibleAtAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalPartiallyVisibleAtOptAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + targetVisiblePortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseHorizontalNotVisibleAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalNotVisibleAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -halfFillerViewExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
     fun reverseHorizontalNotVisibleOptAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(otherViewSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseHorizontalNotVisibleOptAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(
                         x = -(targetSize + otherViewSize + halfFillerViewExtraPortion)))
@@ -203,6 +214,7 @@ class ScrollToEstimatedShortestTest {
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
@@ -210,13 +222,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -224,13 +237,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + targetVisiblePortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
@@ -238,13 +252,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(targetSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -252,13 +267,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -halfFillerViewExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
@@ -266,13 +282,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = -(otherViewSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -280,7 +297,7 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(
                         x = -(targetSize + otherViewSize + halfFillerViewExtraPortion)))
@@ -288,6 +305,7 @@ class ScrollToEstimatedShortestTest {
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
@@ -295,13 +313,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
@@ -309,13 +328,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = (targetSize + targetVisiblePortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -323,13 +343,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = (targetSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
@@ -337,13 +358,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = halfFillerViewExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isLeftAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
@@ -351,13 +373,14 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(x = (otherViewSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
@@ -365,7 +388,7 @@ class ScrollToEstimatedShortestTest {
         setRtl()
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.HORIZONTAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(
                         x = (targetSize + otherViewSize + halfFillerViewExtraPortion)))
@@ -373,78 +396,84 @@ class ScrollToEstimatedShortestTest {
 
         onView(withText("0"))
                 .check(isRightAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultVerticalPartiallyVisibleAtAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun defaultVerticalPartiallyVisibleAtOptAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = (targetSize + targetVisiblePortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultVerticalNotVisibleAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = (targetSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
     fun defaultVerticalNotVisibleAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = halfFillerViewExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun defaultVerticalNotVisibleOptAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = (otherViewSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
     fun defaultVerticalNotVisibleOptAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, false)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, false)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(
                         y = (targetSize + otherViewSize + halfFillerViewExtraPortion)))
@@ -452,78 +481,84 @@ class ScrollToEstimatedShortestTest {
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalPartiallyVisibleAtAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -targetVisiblePortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalPartiallyVisibleAtOptAnchor() {
         val fillerSize = calculateFillerSizeWhenPartiallyVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -(targetSize + targetVisiblePortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
     @Test
     fun reverseVerticalNotVisibleAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, fillerSize, otherViewSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -(targetSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalNotVisibleAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(fillerSize, otherViewSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -halfFillerViewExtraPortion))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isBottomAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     @Test
     fun reverseVerticalNotVisibleOptAnchorWithin() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(otherViewSize, fillerSize, targetSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(y = -(otherViewSize + halfFillerViewExtraPortion)))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
     @Test
     fun reverseVerticalNotVisibleOptAnchorSeam() {
         val fillerSize = calculateFillerSizeWhenNotVisible(RecyclerView.VERTICAL)
         setAdapter(arrayOf("0", "1", "2"), arrayOf(targetSize, otherViewSize, fillerSize))
-        setLayoutManager(LoopingLayoutManager.VERTICAL, true)
+        val layoutManager = setLayoutManager(LoopingLayoutManager.VERTICAL, true)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.scrollBy(
                         y = -(targetSize + otherViewSize + halfFillerViewExtraPortion)))
@@ -531,6 +566,7 @@ class ScrollToEstimatedShortestTest {
 
         onView(withText("0"))
                 .check(isTopAlignedWith(withId(R.id.recycler)))
+        assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
     fun calculateFillerSizeWhenPartiallyVisible(orientation: Int): Int {

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
@@ -1,17 +1,14 @@
 package com.bekawestberg.loopinglayout.test
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.PositionAssertions.*
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
-import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
 import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
@@ -19,7 +16,6 @@ import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Thread.sleep
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/TestUtils.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/TestUtils.kt
@@ -17,6 +17,7 @@
 
 package com.bekawestberg.loopinglayout.test.androidTest.utils
 
+import android.util.Log
 import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
@@ -26,17 +27,20 @@ import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.test.AdapterGeneric
 import com.bekawestberg.loopinglayout.test.R
 
-internal fun setLayoutManager(direction: Int, reverseLayout: Boolean) {
+internal fun setLayoutManager(direction: Int, reverseLayout: Boolean): LoopingLayoutManager {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val layoutManager = LoopingLayoutManager(context, direction, reverseLayout)
     Espresso.onView(ViewMatchers.withId(R.id.recycler))
-            .perform(RecyclerViewActions.setLayoutManager(
-                    LoopingLayoutManager(context, direction, reverseLayout)))
+            .perform(RecyclerViewActions.setLayoutManager(layoutManager))
+    return layoutManager
 }
 
-internal fun setAdapter(data: Array<String>, sizes: Array<Int>? = null) {
+internal fun setAdapter(data: Array<String>, sizes: Array<Int>? = null): AdapterGeneric {
+    val adapter = AdapterGeneric(data, sizes)
     Espresso.onView(ViewMatchers.withId(R.id.recycler))
             .perform(RecyclerViewActions.setAdapter(
-                    AdapterGeneric(data, sizes) as RecyclerView.Adapter<RecyclerView.ViewHolder>))
+                     adapter as RecyclerView.Adapter<RecyclerView.ViewHolder>))
+    return adapter
 }
 
 internal fun setRtl() {

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -28,10 +28,10 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 class ActivityHorizontal : AppCompatActivity() {
     private lateinit var mRecyclerView: RecyclerView
     private var mAdapter: AdapterGeneric = AdapterGeneric(
-            arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"),
+            Array(16) { i -> i.toString()},
             Array(16) { i -> 250})
     private var mLayoutManager =
-            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, true)
+            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,6 +46,10 @@ class ActivityHorizontal : AppCompatActivity() {
         /*mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge*/
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
-        button.setOnClickListener { mAdapter.notifyDataSetChanged() }
+        button.setOnClickListener {
+            mRecyclerView.scrollBy(250, 0)
+            /*mAdapter.updateData(arrayOf("0", "1", "2"), Array(16) { i -> 250 })
+            mAdapter.notifyDataSetChanged()*/
+        }
     }
 }

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -19,6 +19,7 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
@@ -30,7 +31,7 @@ class ActivityHorizontal : AppCompatActivity() {
             arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"),
             Array(16) { i -> 250})
     private var mLayoutManager =
-            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
+            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, true)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,9 +43,9 @@ class ActivityHorizontal : AppCompatActivity() {
         mRecyclerView.setHasFixedSize(true)
         mRecyclerView.layoutManager = mLayoutManager
         mRecyclerView.adapter = mAdapter
-        mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge
+        /*mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge*/
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
-        button.setOnClickListener { mRecyclerView.smoothScrollToPosition(7) }
+        button.setOnClickListener { mAdapter.notifyDataSetChanged() }
     }
 }

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -19,10 +19,8 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
-import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityHorizontal : AppCompatActivity() {

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
@@ -30,7 +30,7 @@ class ActivityVertical : AppCompatActivity() {
     private var mAdapter: AdapterGeneric = AdapterGeneric(
             arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"))
     private var mLayoutManager: LoopingLayoutManager =
-            LoopingLayoutManager(this, LoopingLayoutManager.VERTICAL, false)
+            LoopingLayoutManager(this, LoopingLayoutManager.VERTICAL, true)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,6 +45,6 @@ class ActivityVertical : AppCompatActivity() {
         mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
-        button.setOnClickListener { mRecyclerView.smoothScrollToPosition(7) }
+        button.setOnClickListener { mAdapter.notifyDataSetChanged() }
     }
 }

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/AdapterGeneric.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/AdapterGeneric.kt
@@ -25,7 +25,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
 class AdapterGeneric (
-        private val mDataset: Array<String>,
+        private var mDataset: Array<String>,
         private var mSizes: Array<Int>? = null
 ): RecyclerView.Adapter<AdapterGeneric.MyViewHolder>() {
 
@@ -64,6 +64,11 @@ class AdapterGeneric (
         v.layoutParams = params
 
         Log.v(TAG, "binding")
+    }
+
+    fun updateData(dataSet: Array<String>, sizes: Array<Int>?) {
+        mDataset = dataSet
+        mSizes = sizes
     }
 
     // Return the size of your data set (invoked by the layout manager)


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->

Closes #10 
     
### :star2: Description

<!-- A description of what your PR does -->
Adds a "LayoutRequest" object that can be used to request a re-layout of the recycler. This object can be used to save the state of the recycler and reload it later.

The layout manager now properly supports adapter data updates and orientation changes. I.E it tries to maintain the state of the layout, instead of re-laying out from 0.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->

Added checks to all of the scrollTo unit tests to make sure the topLeftIndex and bottomRightIndex are being properly set.

Also manually tested orientation changes using the following procedure:
1. Started off in portrait orientation.
2. Scrolled the items so half of item 1 was hidden.
3. Rotated the AVD to landscape.
4. Observed how half of item 1 was still hidden.
5. Rotated the AVD back to portrait.
6. Observed how half of item 1 was still hidden.

Tested for all horiz and vert, reversed and not reversed, rtl and ltr.

All unit tests pass.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A