### PR TITLE
fix: Padded recyclers not looping correctly.

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -67,9 +67,16 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
             return layoutRect
         }
 
+    /**
+     * The width of the layout - not the recycler.
+     * AKA the width of the recycler, minus the padding on the left and right.
+     */
     val visibleWidth: Int
         get() = width - paddingLeft - paddingRight
-
+    /**
+     * The height of the layout - not the recycler.
+     * AKA the height of the recycler, minus the padding on the top and bottom.
+     */
     val visibleHeight: Int
         get() = height - paddingTop - paddingBottom
     
@@ -188,7 +195,6 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         val movementDir = getMovementDirectionFromAdapterDirection(-layoutRequest.adapterDirection)
         var prevItem: ListItem? = null
         val size = if (orientation == HORIZONTAL) visibleWidth else visibleHeight
-        Log.v(TAG, "size: $size")
         var sizeFilled = 0
         var index = layoutRequest.anchorIndex
         while (sizeFilled < size) {
@@ -299,10 +305,8 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
             // Scroll just enough to complete the scroll, or bring the view fully into view.
             val amountToScroll = hiddenSize.coerceAtMost(absDelta - amountScrolled)
             amountScrolled += amountToScroll
-            Log.v(TAG, "hiddenSize: $hiddenSize, amountToScroll: $amountToScroll")
             offsetChildren(amountToScroll * -movementDir)
             if (amountScrolled < absDelta) {
-                Log.v(TAG, "amount scrolled: $amountScrolled, absDelta: $absDelta")
                 index = stepIndex(index, movementDir, state)
                 val newView = createViewForIndex(index, movementDir, recycler)
                 val newItem = getItemForView(movementDir, newView)
@@ -434,11 +438,11 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         when {
             isTowardsTopLeft && isTowardsHigherIndices -> {
                 newIndex = index.loopedIncrement(count)
-                if (updateIndex) topLeftIndex = newIndex; Log.v(TAG, "new top: $topLeftIndex"/*, Exception()*/)
+                if (updateIndex) topLeftIndex = newIndex
             }
             isTowardsTopLeft && isTowardsLowerIndices -> {
                 newIndex = index.loopedDecrement(count)
-                if (updateIndex)  topLeftIndex = newIndex; Log.v(TAG, "new top: $topLeftIndex"/*, Exception()*/)
+                if (updateIndex)  topLeftIndex = newIndex
             }
             isTowardsBottomRight && isTowardsHigherIndices -> {
                 newIndex = index.loopedIncrement(count)
@@ -505,8 +509,6 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         recycler: RecyclerView.Recycler,
         state: RecyclerView.State
     ) {
-        Log.v(TAG, "top/left: $topLeftIndex")
-        Log.v(TAG, "bottom/right: $bottomRightIndex")
         val initialIndex = getInitialIndex(movementDir)
         // The first visible item will bump us to zero.
         var distanceFromStart = -1
@@ -551,9 +553,6 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         } else {
             topLeftIndex = initialIndex.loop(changeInPosition, count)
         }
-
-        Log.v(TAG, "top/left after: $topLeftIndex")
-        Log.v(TAG, "bottom/right after: $bottomRightIndex")
     }
 
     /**
@@ -958,7 +957,7 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
     private inner class LeadingRightListItem(view: View) : ListItem(view) {
 
         override val hiddenSize: Int
-            get() = (paddingTop - getDecoratedLeft(view)).coerceAtLeast(0)
+            get() = (paddingLeft - getDecoratedLeft(view)).coerceAtLeast(0)
 
         override val leadingEdge: Int
             get() = getDecoratedRight(view)

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -71,13 +71,13 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
      * The width of the layout - not the recycler.
      * AKA the width of the recycler, minus the padding on the left and right.
      */
-    val visibleWidth: Int
+    val layoutWidth: Int
         get() = width - paddingLeft - paddingRight
     /**
      * The height of the layout - not the recycler.
      * AKA the height of the recycler, minus the padding on the top and bottom.
      */
-    val visibleHeight: Int
+    val layoutHeight: Int
         get() = height - paddingTop - paddingBottom
     
     /**
@@ -194,7 +194,7 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         // Hence the direction is inverted.
         val movementDir = getMovementDirectionFromAdapterDirection(-layoutRequest.adapterDirection)
         var prevItem: ListItem? = null
-        val size = if (orientation == HORIZONTAL) visibleWidth else visibleHeight
+        val size = if (orientation == HORIZONTAL) layoutWidth else layoutHeight
         var sizeFilled = 0
         var index = layoutRequest.anchorIndex
         while (sizeFilled < size) {

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -67,11 +67,11 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
             return layoutRect
         }
 
-    private val visibleWidth: Int
-        get() = width - (paddingLeft + paddingRight)
+    val visibleWidth: Int
+        get() = width - paddingLeft - paddingRight
 
-    private val visibleHeight: Int
-        get() = height - (paddingTop + paddingBottom)
+    val visibleHeight: Int
+        get() = height - paddingTop - paddingBottom
     
     /**
      * Describes the adapter index of the view in the top/left -most position.

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/ViewPickers.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/ViewPickers.kt
@@ -71,9 +71,9 @@ fun childClosestToMiddle(
     var minDistance = Int.MAX_VALUE
     var closestView: View? = null
     val layoutMiddle = if (layoutManager.orientation == LoopingLayoutManager.HORIZONTAL) {
-        layoutManager.paddingLeft + (layoutManager.visibleWidth / 2)
+        layoutManager.paddingLeft + (layoutManager.layoutWidth / 2)
     } else {
-        layoutManager.paddingTop + (layoutManager.visibleHeight / 2)
+        layoutManager.paddingTop + (layoutManager.layoutHeight / 2)
     }
     for (i in 0 until layoutManager.childCount) {
         val view = layoutManager.getChildAt(i) ?: return null

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/ViewPickers.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/ViewPickers.kt
@@ -71,9 +71,9 @@ fun childClosestToMiddle(
     var minDistance = Int.MAX_VALUE
     var closestView: View? = null
     val layoutMiddle = if (layoutManager.orientation == LoopingLayoutManager.HORIZONTAL) {
-        layoutManager.paddingLeft + (layoutManager.width / 2)
+        layoutManager.paddingLeft + (layoutManager.visibleWidth / 2)
     } else {
-        layoutManager.paddingTop + (layoutManager.height / 2)
+        layoutManager.paddingTop + (layoutManager.visibleHeight / 2)
     }
     for (i in 0 until layoutManager.childCount) {
         val view = layoutManager.getChildAt(i) ?: return null

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToAnchorTest.kt
@@ -199,10 +199,11 @@ class FindViewClosestToAnchorTest {
     private fun calculateSizeOfOneItem(orientation: Int): Int {
         val activity = activityRule.activity
         val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val layoutManager: LoopingLayoutManager = recycler.layoutManager as LoopingLayoutManager;
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width - (sizeOfZeroItem + visiblePortionOfSecondZeroItem)
+            layoutManager.visibleWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         } else {
-            recycler.height - (sizeOfZeroItem + visiblePortionOfSecondZeroItem)
+            layoutManager.visibleHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToAnchorTest.kt
@@ -201,9 +201,9 @@ class FindViewClosestToAnchorTest {
         val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
         val layoutManager: LoopingLayoutManager = recycler.layoutManager as LoopingLayoutManager;
         return if (orientation == RecyclerView.HORIZONTAL) {
-            layoutManager.visibleWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            layoutManager.layoutWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         } else {
-            layoutManager.visibleHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            layoutManager.layoutHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToMiddleTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToMiddleTest.kt
@@ -199,10 +199,11 @@ class FindViewClosestToMiddleTest {
     private fun calculateSizeOfOneItem(orientation: Int): Int {
         val activity = activityRule.activity
         val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val layoutManager: LoopingLayoutManager = recycler.layoutManager as LoopingLayoutManager;
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width - (sizeOfZeroItem + visiblePortionOfSecondZeroItem)
+            layoutManager.visibleWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         } else {
-            recycler.height - (sizeOfZeroItem + visiblePortionOfSecondZeroItem)
+            layoutManager.visibleHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToMiddleTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToMiddleTest.kt
@@ -201,9 +201,9 @@ class FindViewClosestToMiddleTest {
         val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
         val layoutManager: LoopingLayoutManager = recycler.layoutManager as LoopingLayoutManager;
         return if (orientation == RecyclerView.HORIZONTAL) {
-            layoutManager.visibleWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            layoutManager.layoutWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         } else {
-            layoutManager.visibleHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            layoutManager.layoutHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/InitialLayoutTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/InitialLayoutTest.kt
@@ -30,6 +30,10 @@ import androidx.test.rule.ActivityTestRule
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isBottomAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isLeftAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isRightAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isTopAlignedWithPadding
 import org.hamcrest.Matcher
 import org.junit.Rule
 import org.junit.Test
@@ -120,18 +124,18 @@ class InitialLayoutTest {
     }
 
     private fun assertStartsLeft() {
-        assertPlacedCorrectly(::isLeftAlignedWith, ::isCompletelyLeftOf)
+        assertPlacedCorrectly(::isLeftAlignedWithPadding, ::isCompletelyLeftOf)
     }
 
     private fun assertStartsRight() {
-        assertPlacedCorrectly(::isRightAlignedWith, ::isCompletelyRightOf)
+        assertPlacedCorrectly(::isRightAlignedWithPadding, ::isCompletelyRightOf)
     }
 
     private fun assertStartsTop() {
-        assertPlacedCorrectly(::isTopAlignedWith, ::isCompletelyAbove)
+        assertPlacedCorrectly(::isTopAlignedWithPadding, ::isCompletelyAbove)
     }
 
     private fun assertStartsBottom() {
-        assertPlacedCorrectly(::isBottomAlignedWith, ::isCompletelyBelow)
+        assertPlacedCorrectly(::isBottomAlignedWithPadding, ::isCompletelyBelow)
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
@@ -11,6 +11,10 @@ import androidx.test.rule.ActivityTestRule
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.addViewsAtAnchorEdge
 import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isBottomAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isLeftAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isRightAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isTopAlignedWithPadding
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
@@ -50,7 +54,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -63,7 +67,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -77,7 +81,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -91,7 +95,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -105,7 +109,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -118,7 +122,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -132,7 +136,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -145,7 +149,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -160,7 +164,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -174,7 +178,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -189,7 +193,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -203,7 +207,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -218,7 +222,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -232,7 +236,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -247,7 +251,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -261,7 +265,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -276,7 +280,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -289,7 +293,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -303,7 +307,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -316,7 +320,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -330,7 +334,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -343,7 +347,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -357,7 +361,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtAnchorEdge))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -370,7 +374,7 @@ class ScrollToAtAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtAnchorEdge))
 
         onView(withText("1"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
@@ -11,6 +11,10 @@ import androidx.test.rule.ActivityTestRule
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
 import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isBottomAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isLeftAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isRightAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isTopAlignedWithPadding
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
@@ -50,7 +54,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -63,7 +67,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -77,7 +81,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -90,7 +94,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -104,7 +108,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -117,7 +121,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -131,7 +135,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -144,7 +148,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -160,7 +164,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -174,7 +178,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -189,7 +193,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -203,7 +207,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -218,7 +222,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -232,7 +236,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -247,7 +251,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -261,7 +265,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -275,7 +279,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -288,7 +292,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -302,7 +306,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -315,7 +319,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -329,7 +333,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -342,7 +346,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -356,7 +360,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -369,7 +373,7 @@ class ScrollToAtOptAnchorTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(1, ::addViewsAtOptAnchorEdge))
 
         onView(withText("1"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
@@ -10,6 +10,10 @@ import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isBottomAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isLeftAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isRightAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isTopAlignedWithPadding
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
@@ -53,7 +57,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -67,7 +71,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -81,7 +85,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -95,7 +99,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -109,7 +113,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -124,7 +128,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -138,7 +142,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -152,7 +156,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -166,7 +170,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -180,7 +184,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -194,7 +198,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -209,7 +213,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -224,7 +228,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -239,7 +243,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -254,7 +258,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -269,7 +273,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -284,7 +288,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -300,7 +304,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -315,7 +319,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -330,7 +334,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -345,7 +349,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -360,7 +364,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isLeftAlignedWith(withId(R.id.recycler)))
+                .check((::isLeftAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -375,7 +379,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -391,7 +395,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isRightAlignedWith(withId(R.id.recycler)))
+                .check((::isRightAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -405,7 +409,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -419,7 +423,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -433,7 +437,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -447,7 +451,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -461,7 +465,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -476,7 +480,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -490,7 +494,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 1 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -504,7 +508,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 1)
     }
 
@@ -518,7 +522,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -532,7 +536,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isBottomAlignedWith(withId(R.id.recycler)))
+                .check((::isBottomAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 
@@ -546,7 +550,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(2))
 
         onView(withText("2"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 2 && layoutManager.bottomRightIndex == 0)
     }
 
@@ -561,7 +565,7 @@ class ScrollToEstimatedShortestTest {
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0))
 
         onView(withText("0"))
-                .check(isTopAlignedWith(withId(R.id.recycler)))
+                .check((::isTopAlignedWithPadding)(withId(R.id.recycler)))
         assert(layoutManager.topLeftIndex == 0 && layoutManager.bottomRightIndex == 2)
     }
 

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/ViewAssertions.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/ViewAssertions.kt
@@ -1,0 +1,155 @@
+package com.bekawestberg.loopinglayout.test.androidTest.utils
+
+import android.graphics.Rect
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewParent
+import androidx.test.espresso.AmbiguousViewMatcherException
+import androidx.test.espresso.NoMatchingViewException
+import androidx.test.espresso.ViewAssertion
+import androidx.test.espresso.assertion.PositionAssertions
+import androidx.test.espresso.core.internal.deps.guava.base.Preconditions
+import androidx.test.espresso.core.internal.deps.guava.base.Predicate
+import androidx.test.espresso.core.internal.deps.guava.collect.Iterables
+import androidx.test.espresso.core.internal.deps.guava.collect.Iterators
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.espresso.util.HumanReadables
+import androidx.test.espresso.util.TreeIterables.breadthFirstViewTraversal
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.Matcher
+import org.hamcrest.StringDescription
+import java.util.*
+
+object ViewAssertions {
+
+    enum class Position {
+        LEFT_PADDING, TOP_PADDING, RIGHT_PADDING, BOTTOM_PADDING
+    }
+
+    fun isLeftAlignedWithPadding(matcher: Matcher<View>): ViewAssertion {
+        return relativePositionOf(matcher, Position.LEFT_PADDING)
+    }
+
+    fun isTopAlignedWithPadding(matcher: Matcher<View>): ViewAssertion {
+        return relativePositionOf(matcher, Position.TOP_PADDING)
+    }
+
+    fun isRightAlignedWithPadding(matcher: Matcher<View>): ViewAssertion {
+        return relativePositionOf(matcher, Position.RIGHT_PADDING)
+    }
+
+    fun isBottomAlignedWithPadding(matcher: Matcher<View>): ViewAssertion {
+        return relativePositionOf(matcher, Position.BOTTOM_PADDING)
+    }
+
+    internal fun relativePositionOf(
+            viewMatcher: Matcher<View>, position: Position): ViewAssertion {
+        checkNotNull(viewMatcher)
+        return ViewAssertion { foundView, noViewException ->
+            val description = StringDescription()
+            if (noViewException != null) {
+                description.appendText(
+                        String.format(
+                                Locale.ROOT,
+                                "' check could not be performed because view '%s' was not found.\n",
+                                noViewException.viewMatcherDescription))
+                throw noViewException
+            } else {
+                // TODO: describe the foundView matcher instead of the foundView itself.
+                description
+                        .appendText("View:")
+                        .appendText(HumanReadables.describe(foundView))
+                        .appendText(" is not ")
+                        .appendText(position.toString())
+                        .appendText(" view ")
+                        .appendText(viewMatcher.toString())
+                assertThat<Boolean>(
+                        description.toString(),
+                        isRelativePosition(
+                                foundView, findView(viewMatcher, getTopViewGroup(foundView)), position),
+                        `is`<Boolean>(true))
+            }
+        }
+    }
+
+    internal fun findView(toView: Matcher<View>, root: View?): View {
+        Preconditions.checkNotNull(toView)
+        Preconditions.checkNotNull(root)
+        val viewPredicate = Predicate<View> { input -> toView.matches(input) }
+        val matchedViewIterator = Iterables.filter(breadthFirstViewTraversal(root!!), viewPredicate).iterator()
+        var matchedView: View? = null
+        while (matchedViewIterator.hasNext()) {
+            if (matchedView != null) {
+                // Ambiguous!
+                throw AmbiguousViewMatcherException.Builder()
+                        .withRootView(root)
+                        .withViewMatcher(toView)
+                        .withView1(matchedView)
+                        .withView2(matchedViewIterator.next())
+                        .withOtherAmbiguousViews(*Iterators.toArray(matchedViewIterator, View::class.java))
+                        .build()
+            } else {
+                matchedView = matchedViewIterator.next()
+            }
+        }
+        if (matchedView == null) {
+            throw NoMatchingViewException.Builder()
+                    .withViewMatcher(toView)
+                    .withRootView(root)
+                    .build()
+        }
+        return matchedView
+    }
+
+    private fun getTopViewGroup(view: View): ViewGroup? {
+        var currentParent: ViewParent? = view.parent
+        var topView: ViewGroup? = null
+        while (currentParent != null) {
+            if (currentParent is ViewGroup) {
+                topView = currentParent
+            }
+            currentParent = currentParent.parent
+        }
+        return topView
+    }
+
+    internal fun isRelativePosition(view1: View, view2: View, position: Position): Boolean {
+        val location1 = IntArray(2)
+        val location2 = IntArray(2)
+        view1.getLocationOnScreen(location1)
+        view2.getLocationOnScreen(location2)
+
+        val rect1 = Rect(
+                location1[0] + view1.paddingLeft,
+                location1[1] + view1.paddingTop,
+                location1[0] + view1.width - view1.paddingRight,
+                location1[1] + view1.height - view1.paddingBottom)
+
+        val rect2 = Rect(
+                location1[0] + view1.paddingLeft,
+                location1[1] + view1.paddingTop,
+                location1[0] + view1.width - view1.paddingRight,
+                location1[1] + view1.height - view1.paddingBottom)
+
+        when (position) {
+            Position.LEFT_PADDING -> return rect1.left == rect2.left
+            Position.TOP_PADDING -> return rect1.top == rect2.top
+            Position.RIGHT_PADDING -> return rect1.right == rect2.right
+            Position.BOTTOM_PADDING -> return rect1.bottom == rect2.bottom
+            /*PositionAssertions.Position.COMPLETELY_LEFT_OF -> return location1[0] + view1.width <= location2[0]
+            PositionAssertions.Position.COMPLETELY_RIGHT_OF -> return location2[0] + view2.width <= location1[0]
+            PositionAssertions.Position.COMPLETELY_ABOVE -> return location1[1] + view1.height <= location2[1]
+            PositionAssertions.Position.COMPLETELY_BELOW -> return location2[1] + view2.height <= location1[1]
+            PositionAssertions.Position.PARTIALLY_LEFT_OF -> return location1[0] < location2[0] && location2[0] < location1[0] + view1.width
+            PositionAssertions.Position.PARTIALLY_RIGHT_OF -> return location2[0] < location1[0] && location1[0] < location2[0] + view2.width
+            PositionAssertions.Position.PARTIALLY_ABOVE -> return location1[1] < location2[1] && location2[1] < location1[1] + view1.height
+            PositionAssertions.Position.PARTIALLY_BELOW -> return location2[1] < location1[1] && location1[1] < location2[1] + view2.height
+            PositionAssertions.Position.LEFT_ALIGNED -> return location1[0] == location2[0]
+            PositionAssertions.Position.RIGHT_ALIGNED -> return location1[0] + view1.width == location2[0] + view2.width
+            PositionAssertions.Position.TOP_ALIGNED -> return location1[1] == location2[1]
+            PositionAssertions.Position.BOTTOM_ALIGNED -> return location1[1] + view1.height == location2[1] + view2.height*/
+            else -> return false
+        }
+    }
+}

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/ViewAssertions.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/androidTest/utils/ViewAssertions.kt
@@ -56,7 +56,6 @@ object ViewAssertions {
                                 noViewException.viewMatcherDescription))
                 throw noViewException
             } else {
-                // TODO: describe the foundView matcher instead of the foundView itself.
                 description
                         .appendText("View:")
                         .appendText(HumanReadables.describe(foundView))
@@ -137,18 +136,6 @@ object ViewAssertions {
             Position.TOP_PADDING -> return rect1.top == rect2.top
             Position.RIGHT_PADDING -> return rect1.right == rect2.right
             Position.BOTTOM_PADDING -> return rect1.bottom == rect2.bottom
-            /*PositionAssertions.Position.COMPLETELY_LEFT_OF -> return location1[0] + view1.width <= location2[0]
-            PositionAssertions.Position.COMPLETELY_RIGHT_OF -> return location2[0] + view2.width <= location1[0]
-            PositionAssertions.Position.COMPLETELY_ABOVE -> return location1[1] + view1.height <= location2[1]
-            PositionAssertions.Position.COMPLETELY_BELOW -> return location2[1] + view2.height <= location1[1]
-            PositionAssertions.Position.PARTIALLY_LEFT_OF -> return location1[0] < location2[0] && location2[0] < location1[0] + view1.width
-            PositionAssertions.Position.PARTIALLY_RIGHT_OF -> return location2[0] < location1[0] && location1[0] < location2[0] + view2.width
-            PositionAssertions.Position.PARTIALLY_ABOVE -> return location1[1] < location2[1] && location2[1] < location1[1] + view1.height
-            PositionAssertions.Position.PARTIALLY_BELOW -> return location2[1] < location1[1] && location1[1] < location2[1] + view2.height
-            PositionAssertions.Position.LEFT_ALIGNED -> return location1[0] == location2[0]
-            PositionAssertions.Position.RIGHT_ALIGNED -> return location1[0] + view1.width == location2[0] + view2.width
-            PositionAssertions.Position.TOP_ALIGNED -> return location1[1] == location2[1]
-            PositionAssertions.Position.BOTTOM_ALIGNED -> return location1[1] + view1.height == location2[1] + view2.height*/
             else -> return false
         }
     }

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
@@ -20,6 +20,7 @@ package com.bekawestberg.loopinglayout.test
 import android.os.Bundle
 
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
@@ -29,8 +30,8 @@ class ActivityVertical : AppCompatActivity() {
     private lateinit var mRecyclerView: RecyclerView
     private var mAdapter: AdapterGeneric = AdapterGeneric(
             arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"))
-    private var mLayoutManager: LoopingLayoutManager =
-            LoopingLayoutManager(this, LoopingLayoutManager.VERTICAL, true)
+    private var mLayoutManager: RecyclerView.LayoutManager =
+            LoopingLayoutManager(this, RecyclerView.VERTICAL, true)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,7 +43,7 @@ class ActivityVertical : AppCompatActivity() {
         mRecyclerView.setHasFixedSize(true)
         mRecyclerView.layoutManager = mLayoutManager
         mRecyclerView.adapter = mAdapter
-        mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge
+        //mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
         button.setOnClickListener { mAdapter.notifyDataSetChanged() }

--- a/test/src/main/res/layout/activity_main.xml
+++ b/test/src/main/res/layout/activity_main.xml
@@ -10,12 +10,16 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler"
-        android:layout_height="0dp"
         android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:padding="50dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+    <!--
+        android:padding="50dp"
+    -->
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #25 
     
### :star2: Description

<!-- A description of what your PR does -->
* Fixed padded recyclers not looping correctly. Yay!
* ListItems now access the height/width directly instead of having it passed.
* Changed some math to use order of operations instead of parens.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Updated all tests to run with a padded recycler view.

All unit tests pass with padded and unpadded recyclers.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A