### PR TITLE
feat: Added temporary snap helper support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-beta04'
+        classpath 'com.android.tools.build:gradle:3.6.0-rc02'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
 

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingSnapHelper.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingSnapHelper.kt
@@ -1,0 +1,14 @@
+package com.bekawestberg.loopinglayout.library
+
+import androidx.recyclerview.widget.LinearSnapHelper
+import androidx.recyclerview.widget.RecyclerView
+
+class LoopingSnapHelper : LinearSnapHelper() {
+    override fun findTargetSnapPosition(
+            layoutManager: RecyclerView.LayoutManager?,
+            velocityX: Int,
+            velocityY: Int
+    ): Int {
+        return RecyclerView.NO_POSITION;
+    }
+}

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -19,10 +19,7 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.LinearSnapHelper
 import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.SnapHelper
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.LoopingSnapHelper
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -33,7 +30,7 @@ class ActivityHorizontal : AppCompatActivity() {
             Array(16) { i -> i.toString()},
             Array(16) { i -> 250})
     private var mLayoutManager =
-            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
+            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, true)
     private var snapHelper = LoopingSnapHelper();
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -19,8 +19,12 @@ package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.LinearSnapHelper
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SnapHelper
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.LoopingSnapHelper
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityHorizontal : AppCompatActivity() {
@@ -30,6 +34,7 @@ class ActivityHorizontal : AppCompatActivity() {
             Array(16) { i -> 250})
     private var mLayoutManager =
             LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
+    private var snapHelper = LoopingSnapHelper();
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,6 +47,8 @@ class ActivityHorizontal : AppCompatActivity() {
         mRecyclerView.layoutManager = mLayoutManager
         mRecyclerView.adapter = mAdapter
         /*mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge*/
+
+        snapHelper?.attachToRecyclerView(mRecyclerView)
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
         button.setOnClickListener {

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
@@ -18,13 +18,10 @@
 package com.bekawestberg.loopinglayout.test
 
 import android.os.Bundle
-
 import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.LoopingSnapHelper
-import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityVertical : AppCompatActivity() {
@@ -33,7 +30,7 @@ class ActivityVertical : AppCompatActivity() {
             Array(16) { i -> i.toString()},
             Array(16) { i -> 250})
     private var mLayoutManager: RecyclerView.LayoutManager =
-            LoopingLayoutManager(this, RecyclerView.VERTICAL, true)
+            LoopingLayoutManager(this, RecyclerView.VERTICAL, false)
     private var snapHelper = LoopingSnapHelper();
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
@@ -23,15 +23,18 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
+import com.bekawestberg.loopinglayout.library.LoopingSnapHelper
 import com.bekawestberg.loopinglayout.library.addViewsAtOptAnchorEdge
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class ActivityVertical : AppCompatActivity() {
     private lateinit var mRecyclerView: RecyclerView
     private var mAdapter: AdapterGeneric = AdapterGeneric(
-            arrayOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"))
+            Array(16) { i -> i.toString()},
+            Array(16) { i -> 250})
     private var mLayoutManager: RecyclerView.LayoutManager =
             LoopingLayoutManager(this, RecyclerView.VERTICAL, true)
+    private var snapHelper = LoopingSnapHelper();
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,6 +47,8 @@ class ActivityVertical : AppCompatActivity() {
         mRecyclerView.layoutManager = mLayoutManager
         mRecyclerView.adapter = mAdapter
         //mLayoutManager.smoothScrollDirectionDecider = ::addViewsAtOptAnchorEdge
+
+        snapHelper?.attachToRecyclerView(mRecyclerView)
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
         button.setOnClickListener { mAdapter.notifyDataSetChanged() }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Work on #7 
     
### :star2: Description

<!-- A description of what your PR does -->
Adds temporary support for snapping, as a better looking solution is not possible at this time. (See [the post](https://groups.google.com/d/msg/android-contrib/aUqoA9A8Z4o/KxPtvXm1AQAJ) I made about it on the android user group)

This forces the default snapping implementation for LayoutManagers that don't implement RecyclerView.SmoothScroller.ScrollVectorProvider. The LoopingLayoutManager does implement this interface, which causes the snap helper to animate badly.

The default implementation looks better, so I decided that was a good temporary solution. 

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
This just triggers the default implementation, so no testing is required.

But I tested all orientations anyway, just to be sure.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
[Snap helper trial 1](https://github.com/BeksOmega/looping-layout/compare/develop...feat/snap-support-trial) 
[Snap helper trial 2](https://github.com/BeksOmega/looping-layout/compare/develop...feat/snap-helper-support)