### PR TITLE
fix: Fixed backgrounding and saving state.

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -1119,6 +1119,12 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
             this.scrollStrategy = scrollStrategy
 
             if (layoutManager != null && state != null) initialize(layoutManager, state)
+
+            if (!hasBeenInitialized
+                    && anchorIndex != RecyclerView.NO_POSITION
+                    && scrollStrategy == null) {
+                hasBeenInitialized = true
+            }
         }
 
         /**

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -20,6 +20,7 @@ package com.bekawestberg.loopinglayout.test
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SnapHelper
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.LoopingSnapHelper
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -31,7 +32,7 @@ class ActivityHorizontal : AppCompatActivity() {
             Array(16) { i -> 250})
     private var mLayoutManager =
             LoopingLayoutManager(this, RecyclerView.HORIZONTAL, true)
-    private var snapHelper = LoopingSnapHelper();
+    private var snapHelper: SnapHelper? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityVertical.kt
@@ -20,6 +20,7 @@ package com.bekawestberg.loopinglayout.test
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SnapHelper
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.LoopingSnapHelper
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -31,7 +32,7 @@ class ActivityVertical : AppCompatActivity() {
             Array(16) { i -> 250})
     private var mLayoutManager: RecyclerView.LayoutManager =
             LoopingLayoutManager(this, RecyclerView.VERTICAL, false)
-    private var snapHelper = LoopingSnapHelper();
+    private var snapHelper: SnapHelper? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
No issue number available.

The LayoutManager was not being properly re-laid out after being backgrounded and then brought back to the foreground. That is now fixed.

This was happening because the LayoutRequest did not realize it was properly initialized, so accessing its properties would throw errors, breaking things.
     
### :star2: Description

<!-- A description of what your PR does -->
Sets the LayoutRequest's hasBeenIntiailzed property to true inside the constructor if all necessary components have been passed.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
1. Scrolled the recycler.
2. Backgrounded the test app.
3. Selected another app.
4. Foregrounded the test app.
5. Observed how the layout was saved correctly.

Tested for all orientations.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
Related to #24 