### PR TITLE
fix: Fixed null exceptions when recycling.

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -537,8 +537,8 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
             }
         }
 
-        // Removing the views after collecting them and putting them in order from greatest -> makes sure we
-        // don't get null errors. See #19
+        // Removing the views after collecting them and putting them in order from greatest -> least
+        // makes sure we don't get null errors. See #19.
         viewsToRemove.sortedDescending().forEach { i ->
             removeAndRecycleViewAt(i, recycler)
         }

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -513,7 +513,7 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         // The first visible item will bump us to zero.
         var distanceFromStart = -1
         var foundVisibleView = false
-        var foundHiddenView = false
+        val viewsToRemove = mutableListOf<Int>()
 
         // We want to loop through the views in the order opposite the direction of movement so that
         // we remove views that have become hidden because of scrolling.
@@ -526,19 +526,24 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         // Ignore hidden views at the start of the range.
         // Only recycle hidden views at the end of the range.
         for (i in range) {
-            val view = getChildAt(i) ?: break
+            val view = getChildAt(i)!!
             if (viewIsVisible(view)) {
                 if (!foundVisibleView) {
                     foundVisibleView = true
                 }
                 distanceFromStart++
             } else if (foundVisibleView){
-                foundHiddenView = true
-                removeAndRecycleViewAt(i, recycler)
+                viewsToRemove.add(i)
             }
         }
 
-        if (!foundHiddenView) {
+        // Removing the views after collecting them and putting them in order from greatest -> makes sure we
+        // don't get null errors. See #19
+        viewsToRemove.sortedDescending().forEach { i ->
+            removeAndRecycleViewAt(i, recycler)
+        }
+
+        if (viewsToRemove.count() == 0) {
             // If we didn't find anything that needed to be disposed, no indices need to be updated.
             return
         }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #19 
     
### :star2: Description

<!-- A description of what your PR does -->
I decided to go with the first option outlined in the issue. I collected all the indices of views that needed to be recycled. Then after collecting I sorted them from greatest -> least, and recycled them.

This makes sure that we don't get null pointers because of indices shifting.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
1. Scrolled to show new views at the top in the vertical test activity.
2. Observed how there were no null pointer exceptions.

I tested the above on develop first (removing the ?: break; child check) and confirmed that there were errors.

All unit tests passed.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A