### PR TITLE
feat: Added accessibility scrolling support.

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -26,6 +26,7 @@ import android.util.AttributeSet
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.OrientationHelper
@@ -689,6 +690,82 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         }
     }
 
+    override fun computeVerticalScrollOffset(state: RecyclerView.State): Int {
+        return computeScrollOffset()
+    }
+
+    override fun computeVerticalScrollRange(state: RecyclerView.State): Int {
+        return computeScrollRange()
+    }
+
+    override fun computeVerticalScrollExtent(state: RecyclerView.State): Int {
+        return computeScrollExtent()
+    }
+
+    override fun computeHorizontalScrollOffset(state: RecyclerView.State): Int {
+        return computeScrollOffset()
+    }
+
+    override fun computeHorizontalScrollRange(state: RecyclerView.State): Int {
+        return computeScrollRange()
+    }
+
+    override fun computeHorizontalScrollExtent(state: RecyclerView.State): Int {
+        return computeScrollExtent()
+    }
+
+    /**
+     * Computes the "offset" the view is from the top. This is documented as needed to support
+     * scrollbars (which the LoopingLayoutManager does not support), but it is also needed to
+     * support TalkBack accessibility gestures. This function returns a constant to ensure that
+     * the layout is always scrollable.
+     */
+    private fun computeScrollOffset(): Int {
+        if (childCount == 0) {
+            return 0
+        }
+        return SCROLL_OFFSET
+    }
+
+    /**
+     * Computes the "range" of scrolling the view supports. This is documented as needed to support
+     * scrollbars (which the LoopingLayoutManager does not support), but it is also needed to
+     * support TalkBack accessibility gestures. This function returns a constant to ensure that
+     * the layout is always scrollable.
+     */
+    private fun computeScrollRange(): Int {
+        if (childCount == 0) {
+            return 0
+        }
+        return SCROLL_RANGE
+    }
+
+    /**
+     * Computes the "extent" of the view. This is documented as needed to support scrollbars (which
+     * the LoopingLayoutManager does not support), but it is also needed to support TalkBack
+     * accessibility gestures. This function returns a constant to ensure that the layout is always
+     * scrollable.
+     */
+    private fun computeScrollExtent(): Int {
+        return 0
+    }
+
+    /**
+     * Adds details to the accessibility event about the range of views that are being shown,
+     * so that it can be told to the user.
+     */
+    override fun onInitializeAccessibilityEvent(
+        recycler: RecyclerView.Recycler,
+        state: RecyclerView.State,
+        event: AccessibilityEvent
+    ) {
+        super.onInitializeAccessibilityEvent(recycler, state, event)
+        if (childCount > 0) {
+            event.fromIndex = topLeftIndex
+            event.toIndex = bottomRightIndex
+        }
+    }
+
     /**
      * Calculates the vector that points to where the target position can be found.
      *
@@ -1222,6 +1299,18 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
          * indices.
          */
         const val TOWARDS_HIGHER_INDICES = 1
+
+        /**
+         * A constant returned by the [.computeScrollOffset] function so that accessibility knows
+         * the layout is always scrollable.
+         *
+         */
+        const val SCROLL_OFFSET = 100
+        /**
+         * A constant returned by the [.computeScrollRange] function so that acessibility knows
+         * the layout is always scrollable.
+         */
+        const val SCROLL_RANGE = 200
     }
 
 }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->

Work on #8 
     
### :star2: Description

<!-- A description of what your PR does -->
Adds support for scrolling the layout via TalkBack gestures. This works by defining the computeScrollOffset, computeScrollRange, and computeScrollExtent functions.

Also tested VoiceAccess support to confirm it is supported by default.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
1. Swiped left and right (as separate gestures).
2. Observed how views were properly selected.
3. Swiped left then right (as one gesture).
4. Observed how the layout was scrolled up/left.
5. Swiped right then left (as one gesture).
6. Observed how the layout was scrolled down/right.

Tested in all orientations, but I did not test in RTL. This is because I tested a normal linear layout in RTL and it was wicked buggy. It doesn't seem like RTL is supported by talkback, which sucks :/

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A