### PR TITLE
fix: nonScrollEdges being calculated incorrectly

### DIFF
--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToAnchorTest.kt
@@ -17,6 +17,7 @@
 
 package com.bekawestberg.loopinglayout.test
 
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.PositionAssertions.*
@@ -27,8 +28,8 @@ import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.library.childClosestToAnchorEdge
-import com.bekawestberg.loopinglayout.test.androidTest.utils.*
 import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewActions.scrollBy
+import com.bekawestberg.loopinglayout.test.androidTest.utils.RecyclerViewMatcher
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setAdapter
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
 import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
@@ -198,12 +199,11 @@ class FindViewClosestToAnchorTest {
 
     private fun calculateSizeOfOneItem(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
-        val layoutManager: LoopingLayoutManager = recycler.layoutManager as LoopingLayoutManager;
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity)
         return if (orientation == RecyclerView.HORIZONTAL) {
-            layoutManager.layoutWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            linearLayout.width - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         } else {
-            layoutManager.layoutHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            linearLayout.height - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToMiddleTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/FindViewClosestToMiddleTest.kt
@@ -17,6 +17,7 @@
 
 package com.bekawestberg.loopinglayout.test
 
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.PositionAssertions.*
@@ -198,12 +199,11 @@ class FindViewClosestToMiddleTest {
 
     private fun calculateSizeOfOneItem(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
-        val layoutManager: LoopingLayoutManager = recycler.layoutManager as LoopingLayoutManager;
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity)
         return if (orientation == RecyclerView.HORIZONTAL) {
-            layoutManager.layoutWidth - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            linearLayout.width - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         } else {
-            layoutManager.layoutHeight - sizeOfZeroItem - visiblePortionOfSecondZeroItem
+            linearLayout.height - sizeOfZeroItem - visiblePortionOfSecondZeroItem
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/InitialLayoutTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/InitialLayoutTest.kt
@@ -27,13 +27,13 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
-import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
-import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
 import com.bekawestberg.loopinglayout.library.LoopingLayoutManager
 import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isBottomAlignedWithPadding
 import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isLeftAlignedWithPadding
 import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isRightAlignedWithPadding
 import com.bekawestberg.loopinglayout.test.androidTest.utils.ViewAssertions.isTopAlignedWithPadding
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setLayoutManager
+import com.bekawestberg.loopinglayout.test.androidTest.utils.setRtl
 import org.hamcrest.Matcher
 import org.junit.Rule
 import org.junit.Test

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtAnchorTest.kt
@@ -1,8 +1,8 @@
 package com.bekawestberg.loopinglayout.test
 
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.PositionAssertions.*
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -380,21 +380,21 @@ class ScrollToAtAnchorTest {
 
     fun calculateNonTargetSizeWhenPartiallyVisible(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity) ?: return 0
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width - targetVisiblePortion
+            linearLayout.width - targetVisiblePortion
         } else {
-            recycler.height - targetVisiblePortion
+            linearLayout.height - targetVisiblePortion
         }
     }
 
     fun calculateNonTargetSizeWhenNotVisible(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity) ?: return 0
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width + nonTargetExtraPortion
+            linearLayout.width + nonTargetExtraPortion
         } else {
-            recycler.height + nonTargetExtraPortion
+            linearLayout.height + nonTargetExtraPortion
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToAtOptAnchorTest.kt
@@ -1,8 +1,8 @@
 package com.bekawestberg.loopinglayout.test
 
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.PositionAssertions.*
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -77,7 +77,7 @@ class ScrollToAtOptAnchorTest {
         setAdapter(arrayOf("0", "1"), arrayOf(targetSize, nonTargetSize))
         val layoutManager = setLayoutManager(LoopingLayoutManager.HORIZONTAL, false)
         onView(withId(R.id.recycler))
-                .perform(RecyclerViewActions.scrollBy(x = nonTargetExtraPortion))
+                .perform(RecyclerViewActions.scrollBy(x = targetSize))
                 .perform(RecyclerViewActions.scrollToPositionViaManager(0, ::addViewsAtOptAnchorEdge))
 
         onView(withText("0"))
@@ -379,21 +379,21 @@ class ScrollToAtOptAnchorTest {
 
     fun calculateNonTargetSizeWhenPartiallyVisible(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity) ?: return 0
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width - targetVisiblePortion
+            linearLayout.width - targetVisiblePortion
         } else {
-            recycler.height - targetVisiblePortion
+            linearLayout.height - targetVisiblePortion
         }
     }
 
     fun calculateNonTargetSizeWhenNotVisible(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity) ?: return 0
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width + nonTargetExtraPortion
+            linearLayout.width + nonTargetExtraPortion
         } else {
-            recycler.height + nonTargetExtraPortion
+            linearLayout.height + nonTargetExtraPortion
         }
     }
 }

--- a/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
+++ b/test/src/androidTest/java/com/bekawestberg/loopinglayout/test/ScrollToEstimatedShortestTest.kt
@@ -1,5 +1,6 @@
 package com.bekawestberg.loopinglayout.test
 
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.PositionAssertions.*
@@ -571,21 +572,21 @@ class ScrollToEstimatedShortestTest {
 
     fun calculateFillerSizeWhenPartiallyVisible(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity) ?: return 0
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width
+            linearLayout.width
         } else {
-            recycler.height
+            linearLayout.height
         }
     }
 
     fun calculateFillerSizeWhenNotVisible(orientation: Int): Int {
         val activity = activityRule.activity
-        val recycler = activity.findViewById<RecyclerView>(R.id.recycler) ?: return 0
+        val linearLayout = activity.findViewById<LinearLayout>(R.id.main_activity) ?: return 0
         return if (orientation == RecyclerView.HORIZONTAL) {
-            recycler.width + fillerViewExtraPortion
+            linearLayout.width + fillerViewExtraPortion
         } else {
-            recycler.height + fillerViewExtraPortion
+            linearLayout.height + fillerViewExtraPortion
         }
     }
 }

--- a/test/src/main/res/layout/activity_main.xml
+++ b/test/src/main/res/layout/activity_main.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
     android:id="@+id/main_activity"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
@@ -10,13 +11,8 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:padding="50dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
     <!--
         android:padding="50dp"
     -->
@@ -32,4 +28,4 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.887" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/test/src/main/res/layout/text_view_generic.xml
+++ b/test/src/main/res/layout/text_view_generic.xml
@@ -5,10 +5,12 @@
     android:id="@+id/textView"
     android:background="#8BC34A"
     android:gravity="center"
-    android:layout_height="100dp"
-    android:layout_width="100dp"
     android:text="TextView"
+    android:layout_height="200dp"
+    android:layout_width="match_parent"
     android:textSize="36sp" />
 
+    <!--android:layout_height="100dp"
+    android:layout_width="100dp"-->
     <!--android:layout_height="match_parent"
     android:layout_width="100dp"-->


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #33
     
### :star2: Description

<!-- A description of what your PR does -->
Changes the LoopingLayoutManager to calculate the non-scrolling edges in the same way that the LinearLayoutManager does.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->

Tests had to be updated. Specifically ones that were setting the item sizes based on the width of the screen.

Now all tests pass.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A