### PR TITLE
fix: onSaveInstanceState null ptr exception.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-rc02'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 19 07:03:40 PST 2019
+#Mon Aug 17 08:59:37 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -158,9 +158,13 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         // All of this information is based on keeping the item currently at the anchor edge
         // at the anchor edge.
         val direction = getMovementDirectionFromAdapterDirection(TOWARDS_LOWER_INDICES)
-        return LayoutRequest(
-                anchorIndex = getInitialIndex(direction),
-                scrollOffset = getInitialItem(direction).hiddenSize)
+        return if (childCount == 0) {  // Occurs if the screen is off on startup.
+            null
+        } else {
+            LayoutRequest(
+                    anchorIndex = getInitialIndex(direction),
+                    scrollOffset = getInitialItem(direction).hiddenSize)
+        }
     }
 
     public override fun onRestoreInstanceState(state: Parcelable?) {


### PR DESCRIPTION
### :clap: Resolves
     
Closes #39 
     
### :star2: Description

Fixes the null ptr exception occuring inside onSaveInstanceState. The issue is that when the screen is off on startup onSaveInstanceState is called (idk why) before any children can be created. So the call [here](https://github.com/BeksOmega/looping-layout/blob/6e219caac7ba9be4c51dc4593da4b577e8e8d6b6/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt#L374) actually returns null. An easy fix is just to check if any children exist. If not we return null from onSaveInstanceSTate, meaning there's no interesting state to save.

Also updates gradle

### :bug: Testing

Could not reproduce #39 using the steps provided.

All unit tests pass.

### :thought_balloon: Other info

N/A