### PR TITLE
fix: layoutRequest not getting reset causing layout errors

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -210,6 +210,11 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         }
     }
 
+    public override fun onLayoutCompleted(state: RecyclerView.State?) {
+        super.onLayoutCompleted(state)
+        layoutRequest.finishProcessing();
+    }
+
     public override fun canScrollVertically(): Boolean {
         return orientation == VERTICAL
     }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #48
     
### :star2: Description

<!-- A description of what your PR does -->
As explained [here](https://github.com/BeksOmega/looping-layout/issues/48#issuecomment-770262278) the layoutRequest was not getting reset, which caused the onLayoutChildren call triggered by the Glide images loading in to re-layout everything with the first item aligned with the anchor edge.

This adds an override of the onLayoutCompleted event that resets the current layoutRequest, eliminating the problem.

onLayoutChildren can be called multiple times, but onLayoutCompleted only gets called once, when the layout is complete, so it avoids the problem with scrollToPosition that caused me to remove the finishProcessing call [here](https://github.com/BeksOmega/looping-layout/pull/34#discussion_r379858009).

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
All unit tests pass!

I also tested this using the demo provided by neikist and I could not reproduce the bug =)
![LoopingWithGlide](https://user-images.githubusercontent.com/25440652/106535759-cad3de80-64ab-11eb-9426-ff9428d127ab.gif)

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
There are still problems with the views not being loaded before they appear on screen (as you can see from the above recording), but that's a different issue hehe