### PR TITLE
feat: Add accessors for getting important adapter indices

### DIFF
--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -73,6 +73,21 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
     /** Describes the adapter index of the view in the bottom/right -most position. */
     public var bottomRightIndex = 0
             private set
+
+    /**
+     * The adapter index of the view at the edge of the layout where the 0th item was
+     * originally laid out.
+     */
+    public val anchorIndex
+        get() = getInitialIndex(getMovementDirectionFromAdapterDirection(TOWARDS_LOWER_INDICES))
+
+    /**
+     * The adapter index of the view at the edge of the layout *opposite* the edge where the 0th
+     * item was originally laid out.
+     */
+    public val optAnchorIndex
+        get() = getInitialIndex(getMovementDirectionFromAdapterDirection(TOWARDS_HIGHER_INDICES))
+
     /**
      * When the layout manager needs to scroll to a position (via smooth scrolling) it needs some
      * method to decide which movement direction to scroll in. This variable stores that method.
@@ -782,6 +797,64 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
             }
         }
         return views
+    }
+
+    /**
+     * Returns the adapter index of the view with the *lowest* adapter index that is even slightly
+     * visible.
+     */
+    public fun findFirstVisibleItemPosition(): Int {
+        var lowestIndex = Int.MAX_VALUE;
+        for (i in 0 until childCount) {
+            val view = getChildAt(i);
+            if (view != null && getPosition(view) < lowestIndex)  {
+                lowestIndex = getPosition(view)
+            }
+        }
+        return lowestIndex;
+    }
+
+    /**
+     * Returns the adapter index of the view with the *lowest* adapter index that is fully visible.
+     */
+    public fun findFirstCompletelyVisibleItemPosition(): Int {
+        var lowestIndex = Int.MAX_VALUE;
+        for (i in 0 until childCount) {
+            val view = getChildAt(i);
+            if (view != null && getPosition(view) < lowestIndex && viewIsFullyVisible(view))  {
+                lowestIndex = getPosition(view)
+            }
+        }
+        return lowestIndex;
+    }
+
+    /**
+     * Returns the adapter index of the view with the *highest* adapter index that is even slightly
+     * visible.
+     */
+    public fun findLastVisibleItemPosition(): Int {
+        var highestIndex = 0;
+        for (i in 0 until childCount) {
+            val view = getChildAt(i)
+            if (view != null && getPosition(view) > highestIndex)  {
+                highestIndex = getPosition(view)
+            }
+        }
+        return highestIndex;
+    }
+
+    /**
+     * Returns the adapter index of the view with the *highest* adapter index that is fully visible.
+     */
+    public fun findLastCompletelyVisibleItemPosition(): Int {
+        var highestIndex = 0;
+        for (i in 0 until childCount) {
+            val view = getChildAt(i)
+            if (view != null && getPosition(view) > highestIndex && viewIsFullyVisible(view))  {
+                highestIndex = getPosition(view)
+            }
+        }
+        return highestIndex;
     }
 
     /**

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -807,7 +807,7 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         var lowestIndex = Int.MAX_VALUE;
         for (i in 0 until childCount) {
             val view = getChildAt(i);
-            if (view != null && getPosition(view) < lowestIndex)  {
+            if (view != null && getPosition(view) < lowestIndex && viewIsVisible(view))  {
                 lowestIndex = getPosition(view)
             }
         }
@@ -836,7 +836,7 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         var highestIndex = 0;
         for (i in 0 until childCount) {
             val view = getChildAt(i)
-            if (view != null && getPosition(view) > highestIndex)  {
+            if (view != null && getPosition(view) > highestIndex && viewIsVisible(view))  {
                 highestIndex = getPosition(view)
             }
         }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #46 
     
### :star2: Description

<!-- A description of what your PR does -->
Adds accessors for:
  * findFirstCompletelyVisibleItemPosition
  * findFirstVisibleItemPosition
  * findLastCompletelyVisibleItemPosition.
  * findLastVisibleItemPosition
  * anchorIndex 
  * optAnchorIndex

I added the last two because they seem more useful than the others for the looping layout in particular. To match the functionality of the LinearLayoutManager the findX functions return the lowest/highest available adapter index, which is usually at the anchor/optAnchor edge for the LinearLayout. But in the case of the LoopingLayout that is not necessarily the case (eg when 0 is in the middle of the layout). The anchorIndex and optAnchorIndex getters provide that information.

### :bug: Testing

1) Modified the ActivityGeneric test activity to log the various added accessors when the FAB is clicked.
2) Tested the layout in various positions (eg 0 fully visible, 0 partially visible, 6 fully visible, 6 partially visible etc) and in reversed vs not reversed mode.
3) Observed that the accessors always return the correct value.

All unit tests pass.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A