### PR TITLE
fix: shrink adapter crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It lives at https://github.com/BeksOmega/looping-layout.
 Add the dependency to your build.gradle file.
 ```groovy
 dependencies {
-    implementation 'com.github.beksomega:loopinglayout:0.4.0'
+    implementation 'com.github.beksomega:loopinglayout:0.4.1'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,8 +27,8 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=0.4.0
-VERSION_CODE=6
+VERSION_NAME=0.4.1
+VERSION_CODE=7
 GROUP=com.github.beksomega
 
 POM_DESCRIPTION=A library that adds a looping layout manager for recycler views.

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -33,6 +33,7 @@ import androidx.recyclerview.widget.OrientationHelper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import androidx.recyclerview.widget.RecyclerView.LayoutParams
+import java.lang.Math.min
 import kotlin.math.abs
 
 class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVectorProvider {
@@ -201,7 +202,7 @@ class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVe
         var prevItem: ListItem? = null
         val size = if (orientation == HORIZONTAL) layoutWidth else layoutHeight
         var sizeFilled = 0
-        var index = layoutRequest.anchorIndex
+        var index = min(layoutRequest.anchorIndex, state.itemCount - 1)
         while (sizeFilled < size) {
             val view = createViewForIndex(index, movementDir, recycler)
             val item = getItemForView(movementDir, view)

--- a/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
+++ b/test/src/main/java/com/bekawestberg/loopinglayout/test/ActivityHorizontal.kt
@@ -31,7 +31,7 @@ class ActivityHorizontal : AppCompatActivity() {
             Array(16) { i -> i.toString()},
             Array(16) { i -> 250})
     private var mLayoutManager =
-            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, true)
+            LoopingLayoutManager(this, RecyclerView.HORIZONTAL, false)
     private var snapHelper: SnapHelper? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -50,9 +50,8 @@ class ActivityHorizontal : AppCompatActivity() {
 
         val button = findViewById<FloatingActionButton>(R.id.fab)
         button.setOnClickListener {
-            mRecyclerView.scrollBy(250, 0)
-            /*mAdapter.updateData(arrayOf("0", "1", "2"), Array(16) { i -> 250 })
-            mAdapter.notifyDataSetChanged()*/
+            mAdapter.updateData(Array(10) { i -> i.toString()}, Array(10) { i -> 250 })
+            mAdapter.notifyDataSetChanged()
         }
     }
 }


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
Closes #61
     
### :star2: Description

<!-- A description of what your PR does -->
Fixes the bug by making sure the initial anchor index does not exceed the available indices. If the initial anchor index *does* initially exceed the available indices, the anchor index gets reset to the max available index.

This PR also updates the readme and build info.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
You can see in this PR te modified ActivityHorizontal file, this was used to reproduce the bug.

1) Scroll so that the item labeled 10 is partially hidden by the left edge.
2) Hit the FAB.
3) Observe how the item labeled 9 is now partially hidden by the left edge, followed by 0, 1, 2, 3 etc. Observe how there was no crash.

All automated tests pass.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
I'm posting this fix tonight, but I'm not going to merge and release it until tomorrow (since it's late where I am).