### PR TITLE
Mark LoopingLayoutManager as open

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Unlike other solutions for creating a looping recycler, which involve modifying 
 project isolates all logic inside the LayoutManager. This allows your Adapter to be reused in other 
 non-looping layouts, and it better conforms to the MVC-like architecture provided by the RecyclerView.
 
-This project was original created and is maintained by [Beka Westberg][linked-in] (BeksOmega).
+This project was originally created and is maintained by [Beka Westberg][linked-in] (BeksOmega).
 
 It lives at https://github.com/BeksOmega/looping-layout.
 

--- a/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
+++ b/library/src/main/java/com/bekawestberg/loopinglayout/library/LoopingLayoutManager.kt
@@ -36,7 +36,7 @@ import androidx.recyclerview.widget.RecyclerView.LayoutParams
 import java.lang.Math.min
 import kotlin.math.abs
 
-class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVectorProvider {
+open class LoopingLayoutManager : LayoutManager, RecyclerView.SmoothScroller.ScrollVectorProvider {
 
     /**
      * Describes the way the layout should be... laid out. Anchor index, anchor edge, and scroll


### PR DESCRIPTION
### :star2: Description

Permits `LoopingLayoutManager` extensibility, akin to `LinearLayoutManager` and siblings.

### :thought_balloon: Other info

The main inspiration here is to support recipes for programmatically disabling scrolling. A number of techniques are listed in
https://stackoverflow.com/questions/30531091/how-to-disable-recyclerview-scrolling, but the most workable seems to be the one where the layout manager is extended and `canScrollVertically()` is overridden.